### PR TITLE
Refactor Agents and add simulation mode

### DIFF
--- a/main.go
+++ b/main.go
@@ -120,52 +120,19 @@ func runController(ctx context.Context, controllerContext *controllercmd.Control
 		os.Exit(1)
 	}
 
-	frameworkAgentAddon, err := policyframework.GetAgentAddon(controllerContext)
-	if err != nil {
-		setupLog.Error(err, "unable to get policy framework agent addon")
-		os.Exit(1)
+	agentFuncs := []func(addonmanager.AddonManager, *controllercmd.ControllerContext) error{
+		policyframework.GetAndAddAgent,
+		configpolicy.GetAndAddAgent,
+		iampolicy.GetAndAddAgent,
+		certpolicy.GetAndAddAgent,
 	}
 
-	err = mgr.AddAgent(frameworkAgentAddon)
-	if err != nil {
-		setupLog.Error(err, "unable to add policy framework agent addon")
-		os.Exit(1)
-	}
-
-	configAgentAddon, err := configpolicy.GetAgentAddon(controllerContext)
-	if err != nil {
-		setupLog.Error(err, "unable to get config policy agent addon")
-		os.Exit(1)
-	}
-
-	err = mgr.AddAgent(configAgentAddon)
-	if err != nil {
-		setupLog.Error(err, "unable to add config policy agent addon")
-		os.Exit(1)
-	}
-
-	iamAgentAddon, err := iampolicy.GetAgentAddon(controllerContext)
-	if err != nil {
-		setupLog.Error(err, "unable to get iam policy agent addon")
-		os.Exit(1)
-	}
-
-	err = mgr.AddAgent(iamAgentAddon)
-	if err != nil {
-		setupLog.Error(err, "unable to add iam policy agent addon")
-		os.Exit(1)
-	}
-
-	certAgentAddon, err := certpolicy.GetAgentAddon(controllerContext)
-	if err != nil {
-		setupLog.Error(err, "unable to get cert policy agent addon")
-		os.Exit(1)
-	}
-
-	err = mgr.AddAgent(certAgentAddon)
-	if err != nil {
-		setupLog.Error(err, "unable to add cert policy agent addon")
-		os.Exit(1)
+	for _, f := range agentFuncs {
+		err := f(mgr, controllerContext)
+		if err != nil {
+			setupLog.Error(err, "unable to get or add agent addon")
+			os.Exit(1)
+		}
 	}
 
 	err = mgr.Start(ctx)

--- a/pkg/addon/certpolicy/agent_addon.go
+++ b/pkg/addon/certpolicy/agent_addon.go
@@ -1,33 +1,21 @@
 package certpolicy
 
 import (
-	"context"
 	"embed"
 
-	"github.com/openshift/library-go/pkg/assets"
 	"github.com/openshift/library-go/pkg/controller/controllercmd"
-	"github.com/openshift/library-go/pkg/operator/events"
-	"github.com/openshift/library-go/pkg/operator/resource/resourceapply"
-	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/client-go/kubernetes"
-	"k8s.io/client-go/kubernetes/scheme"
-	"k8s.io/client-go/rest"
 	"open-cluster-management.io/addon-framework/pkg/addonfactory"
+	"open-cluster-management.io/addon-framework/pkg/addonmanager"
 	"open-cluster-management.io/addon-framework/pkg/agent"
-	"open-cluster-management.io/addon-framework/pkg/utils"
 	addonapiv1alpha1 "open-cluster-management.io/api/addon/v1alpha1"
 	clusterv1 "open-cluster-management.io/api/cluster/v1"
-)
 
-var genericScheme = runtime.NewScheme()
+	policyaddon "github.com/stolostron/governance-policy-addon-controller/pkg/addon"
+)
 
 const (
 	addonName = "cert-policy-controller"
 )
-
-func init() {
-	scheme.AddToScheme(genericScheme)
-}
 
 //go:embed manifests
 //go:embed manifests/managedclusterchart
@@ -41,60 +29,6 @@ var agentPermissionFiles = []string{
 	"manifests/hubpermissions/rolebinding.yaml",
 }
 
-func newRegistrationOption(kubeConfig *rest.Config, recorder events.Recorder, agentName string) *agent.RegistrationOption {
-	return &agent.RegistrationOption{
-		CSRConfigurations: agent.KubeClientSignerConfigurations(addonName, agentName),
-		CSRApproveCheck:   utils.DefaultCSRApprover(agentName),
-		PermissionConfig: func(cluster *clusterv1.ManagedCluster, addon *addonapiv1alpha1.ManagedClusterAddOn) error {
-			kubeclient, err := kubernetes.NewForConfig(kubeConfig)
-			if err != nil {
-				return err
-			}
-
-			for _, file := range agentPermissionFiles {
-				if err := applyManifestFromFile(file, cluster.Name, addon.Name, kubeclient, recorder); err != nil {
-					return err
-				}
-			}
-
-			return nil
-		},
-	}
-}
-
-func applyManifestFromFile(file, clusterName, addonName string, kubeclient *kubernetes.Clientset, recorder events.Recorder) error {
-	groups := agent.DefaultGroups(clusterName, addonName)
-	config := struct {
-		ClusterName string
-		Group       string
-	}{
-		ClusterName: clusterName,
-		Group:       groups[0],
-	}
-
-	results := resourceapply.ApplyDirectly(context.Background(),
-		resourceapply.NewKubeClientHolder(kubeclient),
-		recorder,
-		resourceapply.NewResourceCache(),
-		func(name string) ([]byte, error) {
-			template, err := FS.ReadFile(file)
-			if err != nil {
-				return nil, err
-			}
-			return assets.MustCreateAssetFromTemplate(name, template, config).Data, nil
-		},
-		file,
-	)
-
-	for _, result := range results {
-		if result.Error != nil {
-			return result.Error
-		}
-	}
-
-	return nil
-}
-
 type userValues struct{}
 
 func getValues(cluster *clusterv1.ManagedCluster,
@@ -104,13 +38,18 @@ func getValues(cluster *clusterv1.ManagedCluster,
 }
 
 func GetAgentAddon(controllerContext *controllercmd.ControllerContext) (agent.AgentAddon, error) {
-	registrationOption := newRegistrationOption(
-		controllerContext.KubeConfig,
-		controllerContext.EventRecorder,
-		addonName)
+	registrationOption := policyaddon.NewRegistrationOption(
+		controllerContext,
+		addonName,
+		agentPermissionFiles,
+		FS)
 
 	return addonfactory.NewAgentAddonFactory(addonName, FS, "manifests/managedclusterchart").
 		WithGetValuesFuncs(getValues, addonfactory.GetValuesFromAddonAnnotation).
 		WithAgentRegistrationOption(registrationOption).
 		BuildHelmAgentAddon()
+}
+
+func GetAndAddAgent(mgr addonmanager.AddonManager, controllerContext *controllercmd.ControllerContext) error {
+	return policyaddon.GetAndAddAgent(mgr, addonName, controllerContext, GetAgentAddon)
 }

--- a/pkg/addon/common.go
+++ b/pkg/addon/common.go
@@ -1,0 +1,107 @@
+package addon
+
+import (
+	"context"
+	"embed"
+	"fmt"
+
+	"github.com/openshift/library-go/pkg/assets"
+	"github.com/openshift/library-go/pkg/controller/controllercmd"
+	"github.com/openshift/library-go/pkg/operator/events"
+	"github.com/openshift/library-go/pkg/operator/resource/resourceapply"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/kubernetes/scheme"
+	"open-cluster-management.io/addon-framework/pkg/addonmanager"
+	"open-cluster-management.io/addon-framework/pkg/agent"
+	"open-cluster-management.io/addon-framework/pkg/utils"
+	addonapiv1alpha1 "open-cluster-management.io/api/addon/v1alpha1"
+	clusterv1 "open-cluster-management.io/api/cluster/v1"
+)
+
+var genericScheme = runtime.NewScheme()
+
+func init() {
+	scheme.AddToScheme(genericScheme)
+}
+
+func NewRegistrationOption(
+	controllerContext *controllercmd.ControllerContext,
+	addonName string,
+	agentPermissionFiles []string,
+	filesystem embed.FS,
+) *agent.RegistrationOption {
+	applyManifestFromFile := func(file, clusterName string, kubeclient *kubernetes.Clientset, recorder events.Recorder) error {
+		groups := agent.DefaultGroups(clusterName, addonName)
+		config := struct {
+			ClusterName string
+			Group       string
+		}{
+			ClusterName: clusterName,
+			Group:       groups[0],
+		}
+
+		results := resourceapply.ApplyDirectly(context.Background(),
+			resourceapply.NewKubeClientHolder(kubeclient),
+			recorder,
+			resourceapply.NewResourceCache(),
+			func(name string) ([]byte, error) {
+				template, err := filesystem.ReadFile(file)
+				if err != nil {
+					return nil, err
+				}
+				return assets.MustCreateAssetFromTemplate(name, template, config).Data, nil
+			},
+			file,
+		)
+
+		for _, result := range results {
+			if result.Error != nil {
+				return result.Error
+			}
+		}
+
+		return nil
+	}
+
+	kubeConfig := controllerContext.KubeConfig
+	recorder := controllerContext.EventRecorder
+
+	return &agent.RegistrationOption{
+		CSRConfigurations: agent.KubeClientSignerConfigurations(addonName, addonName),
+		CSRApproveCheck:   utils.DefaultCSRApprover(addonName),
+		PermissionConfig: func(cluster *clusterv1.ManagedCluster, addon *addonapiv1alpha1.ManagedClusterAddOn) error {
+			kubeclient, err := kubernetes.NewForConfig(kubeConfig)
+			if err != nil {
+				return err
+			}
+
+			for _, file := range agentPermissionFiles {
+				if err := applyManifestFromFile(file, cluster.Name, kubeclient, recorder); err != nil {
+					return err
+				}
+			}
+
+			return nil
+		},
+	}
+}
+
+func GetAndAddAgent(
+	mgr addonmanager.AddonManager,
+	addonName string,
+	controllerContext *controllercmd.ControllerContext,
+	getAgent func(*controllercmd.ControllerContext) (agent.AgentAddon, error),
+) error {
+	agentAddon, err := getAgent(controllerContext)
+	if err != nil {
+		return fmt.Errorf("failed getting the %v agent addon: %w", addonName, err)
+	}
+
+	err = mgr.AddAgent(agentAddon)
+	if err != nil {
+		return fmt.Errorf("failed adding the %v agent addon to the manager: %w", addonName, err)
+	}
+
+	return nil
+}

--- a/pkg/addon/configpolicy/agent_addon.go
+++ b/pkg/addon/configpolicy/agent_addon.go
@@ -1,33 +1,21 @@
 package configpolicy
 
 import (
-	"context"
 	"embed"
 
-	"github.com/openshift/library-go/pkg/assets"
 	"github.com/openshift/library-go/pkg/controller/controllercmd"
-	"github.com/openshift/library-go/pkg/operator/events"
-	"github.com/openshift/library-go/pkg/operator/resource/resourceapply"
-	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/client-go/kubernetes"
-	"k8s.io/client-go/kubernetes/scheme"
-	"k8s.io/client-go/rest"
 	"open-cluster-management.io/addon-framework/pkg/addonfactory"
+	"open-cluster-management.io/addon-framework/pkg/addonmanager"
 	"open-cluster-management.io/addon-framework/pkg/agent"
-	"open-cluster-management.io/addon-framework/pkg/utils"
 	addonapiv1alpha1 "open-cluster-management.io/api/addon/v1alpha1"
 	clusterv1 "open-cluster-management.io/api/cluster/v1"
-)
 
-var genericScheme = runtime.NewScheme()
+	policyaddon "github.com/stolostron/governance-policy-addon-controller/pkg/addon"
+)
 
 const (
 	addonName = "config-policy-controller"
 )
-
-func init() {
-	scheme.AddToScheme(genericScheme)
-}
 
 //go:embed manifests
 //go:embed manifests/managedclusterchart
@@ -41,60 +29,6 @@ var agentPermissionFiles = []string{
 	"manifests/hubpermissions/rolebinding.yaml",
 }
 
-func newRegistrationOption(kubeConfig *rest.Config, recorder events.Recorder, agentName string) *agent.RegistrationOption {
-	return &agent.RegistrationOption{
-		CSRConfigurations: agent.KubeClientSignerConfigurations(addonName, agentName),
-		CSRApproveCheck:   utils.DefaultCSRApprover(agentName),
-		PermissionConfig: func(cluster *clusterv1.ManagedCluster, addon *addonapiv1alpha1.ManagedClusterAddOn) error {
-			kubeclient, err := kubernetes.NewForConfig(kubeConfig)
-			if err != nil {
-				return err
-			}
-
-			for _, file := range agentPermissionFiles {
-				if err := applyManifestFromFile(file, cluster.Name, addon.Name, kubeclient, recorder); err != nil {
-					return err
-				}
-			}
-
-			return nil
-		},
-	}
-}
-
-func applyManifestFromFile(file, clusterName, addonName string, kubeclient *kubernetes.Clientset, recorder events.Recorder) error {
-	groups := agent.DefaultGroups(clusterName, addonName)
-	config := struct {
-		ClusterName string
-		Group       string
-	}{
-		ClusterName: clusterName,
-		Group:       groups[0],
-	}
-
-	results := resourceapply.ApplyDirectly(context.Background(),
-		resourceapply.NewKubeClientHolder(kubeclient),
-		recorder,
-		resourceapply.NewResourceCache(),
-		func(name string) ([]byte, error) {
-			template, err := FS.ReadFile(file)
-			if err != nil {
-				return nil, err
-			}
-			return assets.MustCreateAssetFromTemplate(name, template, config).Data, nil
-		},
-		file,
-	)
-
-	for _, result := range results {
-		if result.Error != nil {
-			return result.Error
-		}
-	}
-
-	return nil
-}
-
 type userValues struct{}
 
 func getValues(cluster *clusterv1.ManagedCluster,
@@ -104,13 +38,18 @@ func getValues(cluster *clusterv1.ManagedCluster,
 }
 
 func GetAgentAddon(controllerContext *controllercmd.ControllerContext) (agent.AgentAddon, error) {
-	registrationOption := newRegistrationOption(
-		controllerContext.KubeConfig,
-		controllerContext.EventRecorder,
-		addonName)
+	registrationOption := policyaddon.NewRegistrationOption(
+		controllerContext,
+		addonName,
+		agentPermissionFiles,
+		FS)
 
 	return addonfactory.NewAgentAddonFactory(addonName, FS, "manifests/managedclusterchart").
 		WithGetValuesFuncs(getValues, addonfactory.GetValuesFromAddonAnnotation).
 		WithAgentRegistrationOption(registrationOption).
 		BuildHelmAgentAddon()
+}
+
+func GetAndAddAgent(mgr addonmanager.AddonManager, controllerContext *controllercmd.ControllerContext) error {
+	return policyaddon.GetAndAddAgent(mgr, addonName, controllerContext, GetAgentAddon)
 }

--- a/pkg/addon/iampolicy/agent_addon.go
+++ b/pkg/addon/iampolicy/agent_addon.go
@@ -1,33 +1,21 @@
 package iampolicy
 
 import (
-	"context"
 	"embed"
 
-	"github.com/openshift/library-go/pkg/assets"
 	"github.com/openshift/library-go/pkg/controller/controllercmd"
-	"github.com/openshift/library-go/pkg/operator/events"
-	"github.com/openshift/library-go/pkg/operator/resource/resourceapply"
-	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/client-go/kubernetes"
-	"k8s.io/client-go/kubernetes/scheme"
-	"k8s.io/client-go/rest"
 	"open-cluster-management.io/addon-framework/pkg/addonfactory"
+	"open-cluster-management.io/addon-framework/pkg/addonmanager"
 	"open-cluster-management.io/addon-framework/pkg/agent"
-	"open-cluster-management.io/addon-framework/pkg/utils"
 	addonapiv1alpha1 "open-cluster-management.io/api/addon/v1alpha1"
 	clusterv1 "open-cluster-management.io/api/cluster/v1"
-)
 
-var genericScheme = runtime.NewScheme()
+	policyaddon "github.com/stolostron/governance-policy-addon-controller/pkg/addon"
+)
 
 const (
 	addonName = "iam-policy-controller"
 )
-
-func init() {
-	scheme.AddToScheme(genericScheme)
-}
 
 //go:embed manifests
 //go:embed manifests/managedclusterchart
@@ -41,60 +29,6 @@ var agentPermissionFiles = []string{
 	"manifests/hubpermissions/rolebinding.yaml",
 }
 
-func newRegistrationOption(kubeConfig *rest.Config, recorder events.Recorder, agentName string) *agent.RegistrationOption {
-	return &agent.RegistrationOption{
-		CSRConfigurations: agent.KubeClientSignerConfigurations(addonName, agentName),
-		CSRApproveCheck:   utils.DefaultCSRApprover(agentName),
-		PermissionConfig: func(cluster *clusterv1.ManagedCluster, addon *addonapiv1alpha1.ManagedClusterAddOn) error {
-			kubeclient, err := kubernetes.NewForConfig(kubeConfig)
-			if err != nil {
-				return err
-			}
-
-			for _, file := range agentPermissionFiles {
-				if err := applyManifestFromFile(file, cluster.Name, addon.Name, kubeclient, recorder); err != nil {
-					return err
-				}
-			}
-
-			return nil
-		},
-	}
-}
-
-func applyManifestFromFile(file, clusterName, addonName string, kubeclient *kubernetes.Clientset, recorder events.Recorder) error {
-	groups := agent.DefaultGroups(clusterName, addonName)
-	config := struct {
-		ClusterName string
-		Group       string
-	}{
-		ClusterName: clusterName,
-		Group:       groups[0],
-	}
-
-	results := resourceapply.ApplyDirectly(context.Background(),
-		resourceapply.NewKubeClientHolder(kubeclient),
-		recorder,
-		resourceapply.NewResourceCache(),
-		func(name string) ([]byte, error) {
-			template, err := FS.ReadFile(file)
-			if err != nil {
-				return nil, err
-			}
-			return assets.MustCreateAssetFromTemplate(name, template, config).Data, nil
-		},
-		file,
-	)
-
-	for _, result := range results {
-		if result.Error != nil {
-			return result.Error
-		}
-	}
-
-	return nil
-}
-
 type userValues struct{}
 
 func getValues(cluster *clusterv1.ManagedCluster,
@@ -104,13 +38,18 @@ func getValues(cluster *clusterv1.ManagedCluster,
 }
 
 func GetAgentAddon(controllerContext *controllercmd.ControllerContext) (agent.AgentAddon, error) {
-	registrationOption := newRegistrationOption(
-		controllerContext.KubeConfig,
-		controllerContext.EventRecorder,
-		addonName)
+	registrationOption := policyaddon.NewRegistrationOption(
+		controllerContext,
+		addonName,
+		agentPermissionFiles,
+		FS)
 
 	return addonfactory.NewAgentAddonFactory(addonName, FS, "manifests/managedclusterchart").
 		WithGetValuesFuncs(getValues, addonfactory.GetValuesFromAddonAnnotation).
 		WithAgentRegistrationOption(registrationOption).
 		BuildHelmAgentAddon()
+}
+
+func GetAndAddAgent(mgr addonmanager.AddonManager, controllerContext *controllercmd.ControllerContext) error {
+	return policyaddon.GetAndAddAgent(mgr, addonName, controllerContext, GetAgentAddon)
 }

--- a/pkg/addon/policyframework/agent_addon.go
+++ b/pkg/addon/policyframework/agent_addon.go
@@ -1,34 +1,22 @@
 package policyframework
 
 import (
-	"context"
 	"embed"
 	"strings"
 
-	"github.com/openshift/library-go/pkg/assets"
 	"github.com/openshift/library-go/pkg/controller/controllercmd"
-	"github.com/openshift/library-go/pkg/operator/events"
-	"github.com/openshift/library-go/pkg/operator/resource/resourceapply"
-	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/client-go/kubernetes"
-	"k8s.io/client-go/kubernetes/scheme"
-	"k8s.io/client-go/rest"
 	"open-cluster-management.io/addon-framework/pkg/addonfactory"
+	"open-cluster-management.io/addon-framework/pkg/addonmanager"
 	"open-cluster-management.io/addon-framework/pkg/agent"
-	"open-cluster-management.io/addon-framework/pkg/utils"
 	addonapiv1alpha1 "open-cluster-management.io/api/addon/v1alpha1"
 	clusterv1 "open-cluster-management.io/api/cluster/v1"
-)
 
-var genericScheme = runtime.NewScheme()
+	policyaddon "github.com/stolostron/governance-policy-addon-controller/pkg/addon"
+)
 
 const (
 	addonName = "governance-policy-framework"
 )
-
-func init() {
-	scheme.AddToScheme(genericScheme)
-}
 
 //go:embed manifests
 //go:embed manifests/managedclusterchart
@@ -40,60 +28,6 @@ var agentPermissionFiles = []string{
 	"manifests/hubpermissions/role.yaml",
 	// rolebinding to bind the above role to a certain user group
 	"manifests/hubpermissions/rolebinding.yaml",
-}
-
-func newRegistrationOption(kubeConfig *rest.Config, recorder events.Recorder, agentName string) *agent.RegistrationOption {
-	return &agent.RegistrationOption{
-		CSRConfigurations: agent.KubeClientSignerConfigurations(addonName, agentName),
-		CSRApproveCheck:   utils.DefaultCSRApprover(agentName),
-		PermissionConfig: func(cluster *clusterv1.ManagedCluster, addon *addonapiv1alpha1.ManagedClusterAddOn) error {
-			kubeclient, err := kubernetes.NewForConfig(kubeConfig)
-			if err != nil {
-				return err
-			}
-
-			for _, file := range agentPermissionFiles {
-				if err := applyManifestFromFile(file, cluster.Name, addon.Name, kubeclient, recorder); err != nil {
-					return err
-				}
-			}
-
-			return nil
-		},
-	}
-}
-
-func applyManifestFromFile(file, clusterName, addonName string, kubeclient *kubernetes.Clientset, recorder events.Recorder) error {
-	groups := agent.DefaultGroups(clusterName, addonName)
-	config := struct {
-		ClusterName string
-		Group       string
-	}{
-		ClusterName: clusterName,
-		Group:       groups[0],
-	}
-
-	results := resourceapply.ApplyDirectly(context.Background(),
-		resourceapply.NewKubeClientHolder(kubeclient),
-		recorder,
-		resourceapply.NewResourceCache(),
-		func(name string) ([]byte, error) {
-			template, err := FS.ReadFile(file)
-			if err != nil {
-				return nil, err
-			}
-			return assets.MustCreateAssetFromTemplate(name, template, config).Data, nil
-		},
-		file,
-	)
-
-	for _, result := range results {
-		if result.Error != nil {
-			return result.Error
-		}
-	}
-
-	return nil
 }
 
 type userValues struct {
@@ -123,13 +57,18 @@ func getValues(cluster *clusterv1.ManagedCluster,
 }
 
 func GetAgentAddon(controllerContext *controllercmd.ControllerContext) (agent.AgentAddon, error) {
-	registrationOption := newRegistrationOption(
-		controllerContext.KubeConfig,
-		controllerContext.EventRecorder,
-		addonName)
+	registrationOption := policyaddon.NewRegistrationOption(
+		controllerContext,
+		addonName,
+		agentPermissionFiles,
+		FS)
 
 	return addonfactory.NewAgentAddonFactory(addonName, FS, "manifests/managedclusterchart").
 		WithGetValuesFuncs(getValues, addonfactory.GetValuesFromAddonAnnotation).
 		WithAgentRegistrationOption(registrationOption).
 		BuildHelmAgentAddon()
+}
+
+func GetAndAddAgent(mgr addonmanager.AddonManager, controllerContext *controllercmd.ControllerContext) error {
+	return policyaddon.GetAndAddAgent(mgr, addonName, controllerContext, GetAgentAddon)
 }


### PR DESCRIPTION
The simulation mode should help get things ready to be deployed via helm chart in a way that won't interfere with the current klusterlet-addon-controller setup.