### PR TITLE
Add permissions for setting owner references

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -15,6 +15,17 @@ rules:
   - watch
 - apiGroups:
   - addon.open-cluster-management.io
+  resourceNames:
+  - cert-policy-controller
+  - config-policy-controller
+  - governance-policy-framework
+  - iam-policy-controller
+  resources:
+  - clustermanagementaddons/finalizers
+  verbs:
+  - update
+- apiGroups:
+  - addon.open-cluster-management.io
   resources:
   - managedclusteraddons
   verbs:
@@ -23,6 +34,17 @@ rules:
   - list
   - update
   - watch
+- apiGroups:
+  - addon.open-cluster-management.io
+  resourceNames:
+  - cert-policy-controller
+  - config-policy-controller
+  - governance-policy-framework
+  - iam-policy-controller
+  resources:
+  - managedclusteraddons
+  verbs:
+  - delete
 - apiGroups:
   - addon.open-cluster-management.io
   resourceNames:

--- a/main.go
+++ b/main.go
@@ -61,8 +61,11 @@ import (
 
 //+kubebuilder:rbac:groups=addon.open-cluster-management.io,resources=managedclusteraddons,verbs=create
 //+kubebuilder:rbac:groups=addon.open-cluster-management.io,resources=managedclusteraddons,verbs=get;list;watch;update
+//+kubebuilder:rbac:groups=addon.open-cluster-management.io,resources=managedclusteraddons,verbs=delete,resourceNames=config-policy-controller;governance-policy-framework;iam-policy-controller;cert-policy-controller
 //+kubebuilder:rbac:groups=addon.open-cluster-management.io,resources=managedclusteraddons/finalizers,verbs=update,resourceNames=config-policy-controller;governance-policy-framework;iam-policy-controller;cert-policy-controller
 //+kubebuilder:rbac:groups=addon.open-cluster-management.io,resources=managedclusteraddons/status,verbs=update;patch,resourceNames=config-policy-controller;governance-policy-framework;iam-policy-controller;cert-policy-controller
+
+//+kubebuilder:rbac:groups=addon.open-cluster-management.io,resources=clustermanagementaddons/finalizers,verbs=update,resourceNames=config-policy-controller;governance-policy-framework;iam-policy-controller;cert-policy-controller
 
 // Permissions required for policy-framework
 // (see https://kubernetes.io/docs/reference/access-authn-authz/rbac/#privilege-escalation-prevention-and-bootstrapping)


### PR DESCRIPTION
While testing in a live ACM cluster, it was found that it needed some
more permissions.

Refs:
 - https://github.com/stolostron/backlog/issues/20013

Signed-off-by: Justin Kulikauskas <jkulikau@redhat.com>