### PR TITLE
Manually fast-forward to migrate control of grc addons

### DIFF
--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -38,6 +38,18 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.name
+        - name: CERT_POLICY_CONTROLLER_IMAGE
+          value: quay.io/stolostron/cert-policy-controller:2.5.0-SNAPSHOT-2022-02-22-05-18-45
+        - name: IAM_POLICY_CONTROLLER_IMAGE
+          value: quay.io/stolostron/iam-policy-controller:2.5.0-SNAPSHOT-2022-02-22-05-18-45
+        - name: CONFIG_POLICY_CONTROLLER_IMAGE
+          value: quay.io/stolostron/config-policy-controller:2.5.0-SNAPSHOT-2022-02-22-05-18-45
+        - name: GOVERNANCE_POLICY_SPEC_SYNC_IMAGE
+          value: quay.io/stolostron/governance-policy-spec-sync:2.5.0-SNAPSHOT-2022-02-22-05-18-45
+        - name: GOVERNANCE_POLICY_STATUS_SYNC_IMAGE
+          value: quay.io/stolostron/governance-policy-status-sync:2.5.0-SNAPSHOT-2022-02-22-05-18-45
+        - name: GOVERNANCE_POLICY_TEMPLATE_SYNC_IMAGE
+          value: quay.io/stolostron/governance-policy-template-sync:2.5.0-SNAPSHOT-2022-02-22-05-18-45
         name: manager
         securityContext:
           allowPrivilegeEscalation: false

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -15,6 +15,17 @@ rules:
   - watch
 - apiGroups:
   - addon.open-cluster-management.io
+  resourceNames:
+  - cert-policy-controller
+  - config-policy-controller
+  - governance-policy-framework
+  - iam-policy-controller
+  resources:
+  - clustermanagementaddons/finalizers
+  verbs:
+  - update
+- apiGroups:
+  - addon.open-cluster-management.io
   resources:
   - managedclusteraddons
   verbs:
@@ -23,6 +34,17 @@ rules:
   - list
   - update
   - watch
+- apiGroups:
+  - addon.open-cluster-management.io
+  resourceNames:
+  - cert-policy-controller
+  - config-policy-controller
+  - governance-policy-framework
+  - iam-policy-controller
+  resources:
+  - managedclusteraddons
+  verbs:
+  - delete
 - apiGroups:
   - addon.open-cluster-management.io
   resourceNames:

--- a/main.go
+++ b/main.go
@@ -61,8 +61,11 @@ import (
 
 //+kubebuilder:rbac:groups=addon.open-cluster-management.io,resources=managedclusteraddons,verbs=create
 //+kubebuilder:rbac:groups=addon.open-cluster-management.io,resources=managedclusteraddons,verbs=get;list;watch;update
+//+kubebuilder:rbac:groups=addon.open-cluster-management.io,resources=managedclusteraddons,verbs=delete,resourceNames=config-policy-controller;governance-policy-framework;iam-policy-controller;cert-policy-controller
 //+kubebuilder:rbac:groups=addon.open-cluster-management.io,resources=managedclusteraddons/finalizers,verbs=update,resourceNames=config-policy-controller;governance-policy-framework;iam-policy-controller;cert-policy-controller
 //+kubebuilder:rbac:groups=addon.open-cluster-management.io,resources=managedclusteraddons/status,verbs=update;patch,resourceNames=config-policy-controller;governance-policy-framework;iam-policy-controller;cert-policy-controller
+
+//+kubebuilder:rbac:groups=addon.open-cluster-management.io,resources=clustermanagementaddons/finalizers,verbs=update,resourceNames=config-policy-controller;governance-policy-framework;iam-policy-controller;cert-policy-controller
 
 // Permissions required for policy-framework
 // (see https://kubernetes.io/docs/reference/access-authn-authz/rbac/#privilege-escalation-prevention-and-bootstrapping)

--- a/pkg/addon/certpolicy/agent_addon.go
+++ b/pkg/addon/certpolicy/agent_addon.go
@@ -2,6 +2,7 @@ package certpolicy
 
 import (
 	"embed"
+	"os"
 
 	"github.com/openshift/library-go/pkg/controller/controllercmd"
 	"open-cluster-management.io/addon-framework/pkg/addonfactory"
@@ -33,7 +34,21 @@ type userValues struct{}
 
 func getValues(cluster *clusterv1.ManagedCluster,
 	addon *addonapiv1alpha1.ManagedClusterAddOn) (addonfactory.Values, error) {
-	userValues := userValues{}
+	userValues := policyaddon.UserValues{
+		GlobalValues: policyaddon.GlobalValues{
+			ImagePullPolicy: "IfNotPresent",
+			ImagePullSecret: "open-cluster-management-image-pull-credentials",
+			ImageOverrides: map[string]string{
+				"cert_policy_controller": os.Getenv("CERT_POLICY_CONTROLLER_IMAGE"),
+			},
+			NodeSelector: map[string]string{},
+			ProxyConfig: map[string]string{
+				"HTTP_PROXY":  "",
+				"HTTPS_PROXY": "",
+				"NO_PROXY":    "",
+			},
+		},
+	}
 	return addonfactory.JsonStructToValues(userValues)
 }
 

--- a/pkg/addon/certpolicy/manifests/managedclusterchart/values.yaml
+++ b/pkg/addon/certpolicy/manifests/managedclusterchart/values.yaml
@@ -33,9 +33,12 @@ tolerations:
 clusterName: null
 
 global:
-  imagePullPolicy: Always
-  imagePullSecret: null
+  imagePullPolicy: IfNotPresent
+  imagePullSecret: open-cluster-management-image-pull-credentials
   imageOverrides:
     cert_policy_controller: quay.io/open-cluster-management/cert-policy-controller:latest-2.5
   nodeSelector: {}
-  proxyConfig: {}
+  proxyConfig:
+    HTTP_PROXY: null
+    HTTPS_PROXY: null
+    NO_PROXY: null

--- a/pkg/addon/common.go
+++ b/pkg/addon/common.go
@@ -21,6 +21,18 @@ import (
 	clusterv1 "open-cluster-management.io/api/cluster/v1"
 )
 
+type GlobalValues struct {
+	ImagePullPolicy string            `json:"imagePullPolicy,"`
+	ImagePullSecret string            `json:"imagePullSecret"`
+	ImageOverrides  map[string]string `json:"imageOverrides,"`
+	NodeSelector    map[string]string `json:"nodeSelector,"`
+	ProxyConfig     map[string]string `json:"proxyConfig,"`
+}
+
+type UserValues struct {
+	GlobalValues GlobalValues `json:"global,"`
+}
+
 var genericScheme = runtime.NewScheme()
 
 func init() {

--- a/pkg/addon/configpolicy/agent_addon.go
+++ b/pkg/addon/configpolicy/agent_addon.go
@@ -2,6 +2,7 @@ package configpolicy
 
 import (
 	"embed"
+	"os"
 
 	"github.com/openshift/library-go/pkg/controller/controllercmd"
 	"open-cluster-management.io/addon-framework/pkg/addonfactory"
@@ -29,11 +30,23 @@ var agentPermissionFiles = []string{
 	"manifests/hubpermissions/rolebinding.yaml",
 }
 
-type userValues struct{}
-
 func getValues(cluster *clusterv1.ManagedCluster,
 	addon *addonapiv1alpha1.ManagedClusterAddOn) (addonfactory.Values, error) {
-	userValues := userValues{}
+	userValues := policyaddon.UserValues{
+		GlobalValues: policyaddon.GlobalValues{
+			ImagePullPolicy: "IfNotPresent",
+			ImagePullSecret: "open-cluster-management-image-pull-credentials",
+			ImageOverrides: map[string]string{
+				"config_policy_controller": os.Getenv("CONFIG_POLICY_CONTROLLER_IMAGE"),
+			},
+			NodeSelector: map[string]string{},
+			ProxyConfig: map[string]string{
+				"HTTP_PROXY":  "",
+				"HTTPS_PROXY": "",
+				"NO_PROXY":    "",
+			},
+		},
+	}
 	return addonfactory.JsonStructToValues(userValues)
 }
 

--- a/pkg/addon/configpolicy/manifests/managedclusterchart/templates/deployment.yaml
+++ b/pkg/addon/configpolicy/manifests/managedclusterchart/templates/deployment.yaml
@@ -67,7 +67,7 @@ spec:
       volumes:
         - name: klusterlet-config
           secret:
-            secretName: {{ .Values.hubKubeconfigSecret }}
+            secretName: {{ .Values.hubKubeConfigSecret }}
       {{- if .Values.global.imagePullSecret }}
       imagePullSecrets:
       - name: "{{ .Values.global.imagePullSecret }}"

--- a/pkg/addon/configpolicy/manifests/managedclusterchart/values.yaml
+++ b/pkg/addon/configpolicy/manifests/managedclusterchart/values.yaml
@@ -6,7 +6,7 @@ nameOverride: null
 org: open-cluster-management
 replicas: 1
 
-hubKubeconfigSecret: config-policy-controller-hub-kubeconfig
+hubKubeConfigSecret: config-policy-controller-hub-kubeconfig
 
 resources:
   requests:
@@ -28,9 +28,12 @@ tolerations:
 clusterName: null
 
 global: 
-  imagePullPolicy: Always 
-  imagePullSecret: null
+  imagePullPolicy: IfNotPresent
+  imagePullSecret: open-cluster-management-image-pull-credentials
   imageOverrides: 
     config_policy_controller: quay.io/open-cluster-management/config-policy-controller:edge
   nodeSelector: {}
-  proxyConfig: {}
+  proxyConfig:
+    HTTP_PROXY: null
+    HTTPS_PROXY: null
+    NO_PROXY: null

--- a/pkg/addon/iampolicy/agent_addon.go
+++ b/pkg/addon/iampolicy/agent_addon.go
@@ -2,6 +2,7 @@ package iampolicy
 
 import (
 	"embed"
+	"os"
 
 	"github.com/openshift/library-go/pkg/controller/controllercmd"
 	"open-cluster-management.io/addon-framework/pkg/addonfactory"
@@ -33,7 +34,21 @@ type userValues struct{}
 
 func getValues(cluster *clusterv1.ManagedCluster,
 	addon *addonapiv1alpha1.ManagedClusterAddOn) (addonfactory.Values, error) {
-	userValues := userValues{}
+	userValues := policyaddon.UserValues{
+		GlobalValues: policyaddon.GlobalValues{
+			ImagePullPolicy: "IfNotPresent",
+			ImagePullSecret: "open-cluster-management-image-pull-credentials",
+			ImageOverrides: map[string]string{
+				"iam_policy_controller": os.Getenv("IAM_POLICY_CONTROLLER_IMAGE"),
+			},
+			NodeSelector: map[string]string{},
+			ProxyConfig: map[string]string{
+				"HTTP_PROXY":  "",
+				"HTTPS_PROXY": "",
+				"NO_PROXY":    "",
+			},
+		},
+	}
 	return addonfactory.JsonStructToValues(userValues)
 }
 

--- a/pkg/addon/iampolicy/manifests/managedclusterchart/values.yaml
+++ b/pkg/addon/iampolicy/manifests/managedclusterchart/values.yaml
@@ -39,9 +39,12 @@ tolerations:
 clusterName: null
 
 global:
-  imagePullPolicy: Always
-  imagePullSecret: null
+  imagePullPolicy: IfNotPresent
+  imagePullSecret: open-cluster-management-image-pull-credentials
   imageOverrides:
     iam_policy_controller: quay.io/open-cluster-management/iam-policy-controller:latest-2.5
   nodeSelector: {}
-  proxyConfig: {}
+  proxyConfig:
+    HTTP_PROXY: null
+    HTTPS_PROXY: null
+    NO_PROXY: null

--- a/pkg/addon/policyframework/agent_addon.go
+++ b/pkg/addon/policyframework/agent_addon.go
@@ -2,6 +2,7 @@ package policyframework
 
 import (
 	"embed"
+	"os"
 	"strings"
 
 	"github.com/openshift/library-go/pkg/controller/controllercmd"
@@ -31,13 +32,29 @@ var agentPermissionFiles = []string{
 }
 
 type userValues struct {
-	OnMulticlusterHub bool `json:"onMulticlusterHub"`
+	OnMulticlusterHub bool                     `json:"onMulticlusterHub"`
+	GlobalValues      policyaddon.GlobalValues `json:"global"`
 }
 
 func getValues(cluster *clusterv1.ManagedCluster,
 	addon *addonapiv1alpha1.ManagedClusterAddOn) (addonfactory.Values, error) {
 	userValues := userValues{
 		OnMulticlusterHub: false,
+		GlobalValues: policyaddon.GlobalValues{
+			ImagePullPolicy: "IfNotPresent",
+			ImagePullSecret: "open-cluster-management-image-pull-credentials",
+			ImageOverrides: map[string]string{
+				"governance_policy_spec_sync":     os.Getenv("GOVERNANCE_POLICY_SPEC_SYNC_IMAGE"),
+				"governance_policy_status_sync":   os.Getenv("GOVERNANCE_POLICY_STATUS_SYNC_IMAGE"),
+				"governance_policy_template_sync": os.Getenv("GOVERNANCE_POLICY_TEMPLATE_SYNC_IMAGE"),
+			},
+			NodeSelector: map[string]string{},
+			ProxyConfig: map[string]string{
+				"HTTP_PROXY":  "",
+				"HTTPS_PROXY": "",
+				"NO_PROXY":    "",
+			},
+		},
 	}
 	// special case for local-cluster
 	if cluster.Name == "local-cluster" {

--- a/pkg/addon/policyframework/manifests/managedclusterchart/templates/deployment.yaml
+++ b/pkg/addon/policyframework/manifests/managedclusterchart/templates/deployment.yaml
@@ -10,7 +10,6 @@ metadata:
     chart: {{ include "controller.chart" . }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
-    hubKubeconfigSecret: {{ .Values.hubKubeconfigSecret }}
 spec:
   replicas: {{ .Values.replicas }}
   selector:
@@ -169,7 +168,7 @@ spec:
       volumes:
         - name: klusterlet-config
           secret:
-            secretName: {{ .Values.hubKubeconfigSecret }}
+            secretName: {{ .Values.hubKubeConfigSecret }}
       {{- if .Values.global.imagePullSecret }}
       imagePullSecrets:
       - name: "{{ .Values.global.imagePullSecret }}"

--- a/pkg/addon/policyframework/manifests/managedclusterchart/values.yaml
+++ b/pkg/addon/policyframework/manifests/managedclusterchart/values.yaml
@@ -7,7 +7,7 @@ onMulticlusterHub: false
 
 org: open-cluster-management
 replicas: 1
-hubKubeconfigSecret: governance-policy-framework-hub-kubeconfig
+hubKubeConfigSecret: governance-policy-framework-hub-kubeconfig
 
 resources:
   requests:
@@ -29,11 +29,14 @@ tolerations:
 clusterName: null
 
 global: 
-  imagePullPolicy: Always
-  imagePullSecret: null
+  imagePullPolicy: IfNotPresent
+  imagePullSecret: open-cluster-management-image-pull-credentials
   imageOverrides: 
     governance_policy_spec_sync: quay.io/open-cluster-management/governance-policy-spec-sync:edge
     governance_policy_status_sync: quay.io/open-cluster-management/governance-policy-status-sync:edge
     governance_policy_template_sync: quay.io/open-cluster-management/governance-policy-template-sync:edge
   nodeSelector: {}
-  proxyConfig: {}
+  proxyConfig:
+    HTTP_PROXY: null
+    HTTPS_PROXY: null
+    NO_PROXY: null


### PR DESCRIPTION
The klusterlet-addon-controller was already updated to stop creating the grc addons, which means right now nothing is creating the deployments on managed clusters in snapshot builds. The helm chart has already been updated as well - but the fast-forward here is blocked by some other GRC test failures.