### PR TITLE
Fix framework permissions

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -122,6 +122,16 @@ rules:
   - update
   - watch
 - apiGroups:
+  - ""
+  resourceNames:
+  - policy-encryption-key
+  resources:
+  - secrets
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
   - policy.open-cluster-management.io
   resources:
   - policies

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -111,8 +111,8 @@ rules:
   resourceNames:
   - cert-policy-controller
   - config-policy-controller
+  - governance-policy-framework
   - iam-policy-controller
-  - policy-framework
   resources:
   - leases
   verbs:

--- a/main.go
+++ b/main.go
@@ -48,7 +48,7 @@ import (
 // RBAC below will need to be updated if/when new policy controllers are added.
 
 //+kubebuilder:rbac:groups=coordination.k8s.io,resources=leases,verbs=create
-//+kubebuilder:rbac:groups=coordination.k8s.io,resources=leases,verbs=get;list;watch;patch;update,resourceNames=policy-framework;config-policy-controller;iam-policy-controller;cert-policy-controller
+//+kubebuilder:rbac:groups=coordination.k8s.io,resources=leases,verbs=get;list;watch;patch;update,resourceNames=governance-policy-framework;config-policy-controller;iam-policy-controller;cert-policy-controller
 
 //+kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=clusterroles,verbs=create
 //+kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=clusterroles,verbs=get;update;patch;delete,resourceNames="open-cluster-management:policy-framework-hub";"open-cluster-management:config-policy-controller-hub";"open-cluster-management:iam-policy-controller-hub";"open-cluster-management:cert-policy-controller-hub"

--- a/main.go
+++ b/main.go
@@ -73,6 +73,7 @@ import (
 //+kubebuilder:rbac:groups=policy.open-cluster-management.io,resources=policies,verbs=create;delete;get;list;patch;update;watch
 //+kubebuilder:rbac:groups=policy.open-cluster-management.io,resources=policies/finalizers,verbs=update
 //+kubebuilder:rbac:groups=policy.open-cluster-management.io,resources=policies/status,verbs=get;patch;update
+//+kubebuilder:rbac:groups=core,resources=secrets,resourceNames=policy-encryption-key,verbs=get;list;watch
 
 var (
 	setupLog    = ctrl.Log.WithName("setup")

--- a/pkg/addon/policyframework/manifests/hubpermissions/role.yaml
+++ b/pkg/addon/policyframework/manifests/hubpermissions/role.yaml
@@ -9,7 +9,7 @@ rules:
   resources:
   - leases
   resourceNames:
-  - policy-framework
+  - governance-policy-framework
   verbs:
   - get
   - list

--- a/pkg/addon/policyframework/manifests/hubpermissions/role.yaml
+++ b/pkg/addon/policyframework/manifests/hubpermissions/role.yaml
@@ -49,3 +49,14 @@ rules:
   - get
   - patch
   - update
+# Rule for secret-sync
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  resourceNames:
+  - policy-encryption-key
+  verbs:
+  - get
+  - list
+  - watch


### PR DESCRIPTION
When running on a separate managed cluster (not "local-cluster") the spec-sync controller was restarting and logging errors about not being able to get this secret from the hub.

The issue with the lease name would probably only have been seen when testing with OCP 3.11 clusters.