### PR TITLE
Add and run crd-sync script

### DIFF
--- a/.github/workflows/crd-sync.yml
+++ b/.github/workflows/crd-sync.yml
@@ -1,0 +1,36 @@
+name: CRD Sync Validation
+
+on:
+  schedule:
+    # every midnight
+    - cron:  '0 0 * * *'
+
+defaults:
+  run:
+    shell: bash
+    working-directory: governance-policy-addon-controller
+
+jobs:
+  crd-sync-validation:
+    runs-on: ubuntu-latest
+    name: CRD Sync Validation
+    steps:
+    - name: Checkout 
+      uses: actions/checkout@v2
+      with:
+        path: governance-policy-addon-controller
+
+    - name: Set up Go - ${{ matrix.go }}
+      uses: actions/setup-go@v2
+      id: go
+      with:
+        go-version: '1.17'
+
+    - name: Synchronize CRDs
+      run: |
+        ./build/crd-sync.sh
+
+    - name: Check for any changes
+      run: |
+        git diff --exit-code
+

--- a/build/crd-sync.sh
+++ b/build/crd-sync.sh
@@ -1,0 +1,88 @@
+#!/usr/bin/env bash
+
+set -euxo pipefail  # exit on errors and unset vars, and stop on the first error in a "pipeline"
+
+BRANCH="${BRANCH:-main}"
+
+mkdir -p .go
+
+# Clone repositories containing the CRD definitions
+for REPO in cert-policy-controller config-policy-controller iam-policy-controller governance-policy-propagator
+do
+    git clone -b "${BRANCH}" --depth 1 https://github.com/stolostron/${REPO}.git .go/${REPO}
+done
+
+(
+    cd .go/cert-policy-controller
+    cp deploy/crds/policy.open-cluster-management.io_certificatepolicies.yaml ../cert-policy-crd-v1.yaml
+    CRD_OPTIONS="crd:trivialVersions=true,crdVersions=v1beta1" make manifests
+    cp deploy/crds/policy.open-cluster-management.io_certificatepolicies.yaml ../cert-policy-crd-v1beta1.yaml
+)
+
+(
+    cd .go/config-policy-controller
+    cp deploy/crds/policy.open-cluster-management.io_configurationpolicies.yaml ../config-policy-crd-v1.yaml
+    CRD_OPTIONS="crd:trivialVersions=true,crdVersions=v1beta1" make manifests
+    cp deploy/crds/policy.open-cluster-management.io_configurationpolicies.yaml ../config-policy-crd-v1beta1.yaml
+)
+
+(
+    cd .go/iam-policy-controller
+    cp deploy/crds/policy.open-cluster-management.io_iampolicies.yaml ../iam-policy-crd-v1.yaml
+    CRD_OPTIONS="crd:trivialVersions=true,crdVersions=v1beta1" make manifests
+    cp deploy/crds/policy.open-cluster-management.io_iampolicies.yaml ../iam-policy-crd-v1beta1.yaml
+)
+
+(
+    cd .go/governance-policy-propagator
+    cp deploy/crds/policy.open-cluster-management.io_policies.yaml ../policy-crd-v1.yaml
+    CRD_OPTIONS="crd:trivialVersions=true,crdVersions=v1beta1" make manifests
+    cp deploy/crds/policy.open-cluster-management.io_policies.yaml ../policy-crd-v1beta1.yaml
+)
+
+cat > pkg/addon/certpolicy/manifests/managedclusterchart/templates/policy.open-cluster-management.io_certificatepolicy_crd.yaml << EOF
+# Copyright Contributors to the Open Cluster Management project
+
+{{- if semverCompare "< 1.16.0" .Capabilities.KubeVersion.Version }}
+$(cat .go/cert-policy-crd-v1beta1.yaml)
+{{ else }}
+$(cat .go/cert-policy-crd-v1.yaml)
+{{- end }}
+EOF
+
+cat > pkg/addon/configpolicy/manifests/managedclusterchart/templates/policy.open-cluster-management.io_configurationpolicies_crd.yaml << EOF
+# Copyright Contributors to the Open Cluster Management project
+
+{{- if semverCompare "< 1.16.0" .Capabilities.KubeVersion.Version }}
+$(cat .go/config-policy-crd-v1beta1.yaml)
+{{ else }}
+$(cat .go/config-policy-crd-v1.yaml)
+{{- end }}
+EOF
+
+cat > pkg/addon/iampolicy/manifests/managedclusterchart/templates/policy.open-cluster-management.io_iampolicy_crd.yaml << EOF
+# Copyright Contributors to the Open Cluster Management project
+
+{{- if semverCompare "< 1.16.0" .Capabilities.KubeVersion.Version }}
+$(cat .go/iam-policy-crd-v1beta1.yaml)
+{{ else }}
+$(cat .go/iam-policy-crd-v1.yaml)
+{{- end }}
+EOF
+
+cat > pkg/addon/policyframework/manifests/managedclusterchart/templates/policy.open-cluster-management.io_policies_crd.yaml << EOF
+# Copyright Contributors to the Open Cluster Management project
+
+{{- if semverCompare "< 1.16.0" .Capabilities.KubeVersion.Version }}
+$(cat .go/policy-crd-v1beta1.yaml)
+{{ else }}
+$(cat .go/policy-crd-v1.yaml)
+{{- end }}
+EOF
+
+# Clean up the repositories - the chmod is necessary because Go makes some read-only things.
+for REPO in cert-policy-controller config-policy-controller iam-policy-controller governance-policy-propagator
+do
+    chmod -R +rw .go/${REPO}
+    rm -rf .go/${REPO}
+done

--- a/pkg/addon/certpolicy/manifests/managedclusterchart/templates/policy.open-cluster-management.io_certificatepolicy_crd.yaml
+++ b/pkg/addon/certpolicy/manifests/managedclusterchart/templates/policy.open-cluster-management.io_certificatepolicy_crd.yaml
@@ -4,9 +4,9 @@
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.6.1
   creationTimestamp: null
-  labels:
-    controller-tools.k8s.io: "1.0"
   name: certificatepolicies.policy.open-cluster-management.io
 spec:
   group: policy.open-cluster-management.io
@@ -15,8 +15,6 @@ spec:
     listKind: CertificatePolicyList
     plural: certificatepolicies
     singular: certificatepolicy
-    shortNames:
-    - certpl
   scope: Namespaced
   subresources:
     status: {}
@@ -36,11 +34,11 @@ spec:
           description: CertificatePolicySpec defines the desired state of CertificatePolicy
           properties:
             allowedSANPattern:
-              description: A pattern that must match any defined SAN entries in the certificate for the certificate to be compliant.  Golang's regexp syntax only
+              description: A pattern that must match any defined SAN entries in the certificate for the certificate to be compliant.  Golang's regexp syntax only.
               minLength: 1
               type: string
             disallowedSANPattern:
-              description: A pattern that must not match any defined SAN entries in the certificate for the certificate to be compliant. Golang's regexp syntax only
+              description: A pattern that must not match any defined SAN entries in the certificate for the certificate to be compliant. Golang's regexp syntax only.
               minLength: 1
               type: string
             labelSelector:
@@ -49,20 +47,16 @@ spec:
                 type: string
               type: object
             maximumCADuration:
-              description: Maximum CA duration for a signing certificate, longer duration is considered non-compliant. Golang's time units only
-              pattern: ^(?:(?:[0-9]+(?:.[0-9])?)(?:h|m|s|(?:ms)|(?:us)|(?:ns)))+$
+              description: Maximum CA duration for a signing certificate, longer duration is considered non-compliant. Golang's time units only.
               type: string
             maximumDuration:
-              description: Maximum duration for a certificate, longer duration is considered non-compliant. Golang's time units only
-              pattern: ^(?:(?:[0-9]+(?:.[0-9])?)(?:h|m|s|(?:ms)|(?:us)|(?:ns)))+$
+              description: Maximum duration for a certificate, longer duration is considered non-compliant. Golang's time units only.
               type: string
             minimumCADuration:
-              description: Minimum CA duration before a signing certificate expires that it is considered non-compliant. Golang's time units only
-              pattern: ^(?:(?:[0-9]+(?:.[0-9])?)(?:h|m|s|(?:ms)|(?:us)|(?:ns)))+$
+              description: Minimum CA duration before a signing certificate expires that it is considered non-compliant. Golang's time units only.
               type: string
             minimumDuration:
-              description: Minimum duration before a certificate expires that it is considered non-compliant. Golang's time units only
-              pattern: ^(?:(?:[0-9]+(?:.[0-9])?)(?:h|m|s|(?:ms)|(?:us)|(?:ns)))+$
+              description: Minimum duration before a certificate expires that it is considered non-compliant. Golang's time units only.
               type: string
             namespaceSelector:
               description: selecting a list of namespaces where the policy applies
@@ -106,9 +100,11 @@ spec:
               additionalProperties:
                 description: CompliancyDetails defines the all the details related to whether or not the policy is compliant
                 properties:
-                  NonCompliantCertificates:
+                  message:
+                    type: string
+                  nonCompliantCertificates:
                     type: integer
-                  NonCompliantCertificatesList:
+                  nonCompliantCertificatesList:
                     additionalProperties:
                       description: Cert contains its related secret and when it expires
                       properties:
@@ -132,13 +128,11 @@ spec:
                           type: string
                       type: object
                     type: object
-                  message:
-                    type: string
                 type: object
               description: map of namespaces to its compliancy details
               type: object
             compliant:
-              description: Compliant, NonCompliant, UnkownCompliancy
+              description: Compliant, NonCompliant, UnknownCompliancy
               type: string
           type: object
       type: object
@@ -154,13 +148,11 @@ status:
   conditions: []
   storedVersions: []
 {{ else }}
-
----
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.5.0
+    controller-gen.kubebuilder.io/version: v0.6.1
   creationTimestamp: null
   name: certificatepolicies.policy.open-cluster-management.io
 spec:
@@ -189,11 +181,11 @@ spec:
             description: CertificatePolicySpec defines the desired state of CertificatePolicy
             properties:
               allowedSANPattern:
-                description: A pattern that must match any defined SAN entries in the certificate for the certificate to be compliant.  Golang's regexp syntax only
+                description: A pattern that must match any defined SAN entries in the certificate for the certificate to be compliant.  Golang's regexp syntax only.
                 minLength: 1
                 type: string
               disallowedSANPattern:
-                description: A pattern that must not match any defined SAN entries in the certificate for the certificate to be compliant. Golang's regexp syntax only
+                description: A pattern that must not match any defined SAN entries in the certificate for the certificate to be compliant. Golang's regexp syntax only.
                 minLength: 1
                 type: string
               labelSelector:
@@ -202,19 +194,19 @@ spec:
                   type: string
                 type: object
               maximumCADuration:
-                description: Maximum CA duration for a signing certificate, longer duration is considered non-compliant. Golang's time units only
+                description: Maximum CA duration for a signing certificate, longer duration is considered non-compliant. Golang's time units only.
                 pattern: ^(?:(?:[0-9]+(?:.[0-9])?)(?:h|m|s|(?:ms)|(?:us)|(?:ns)))+$
                 type: string
               maximumDuration:
-                description: Maximum duration for a certificate, longer duration is considered non-compliant. Golang's time units only
+                description: Maximum duration for a certificate, longer duration is considered non-compliant. Golang's time units only.
                 pattern: ^(?:(?:[0-9]+(?:.[0-9])?)(?:h|m|s|(?:ms)|(?:us)|(?:ns)))+$
                 type: string
               minimumCADuration:
-                description: Minimum CA duration before a signing certificate expires that it is considered non-compliant. Golang's time units only
+                description: Minimum CA duration before a signing certificate expires that it is considered non-compliant. Golang's time units only.
                 pattern: ^(?:(?:[0-9]+(?:.[0-9])?)(?:h|m|s|(?:ms)|(?:us)|(?:ns)))+$
                 type: string
               minimumDuration:
-                description: Minimum duration before a certificate expires that it is considered non-compliant. Golang's time units only
+                description: Minimum duration before a certificate expires that it is considered non-compliant. Golang's time units only.
                 pattern: ^(?:(?:[0-9]+(?:.[0-9])?)(?:h|m|s|(?:ms)|(?:us)|(?:ns)))+$
                 type: string
               namespaceSelector:
@@ -259,9 +251,11 @@ spec:
                 additionalProperties:
                   description: CompliancyDetails defines the all the details related to whether or not the policy is compliant
                   properties:
-                    NonCompliantCertificates:
+                    message:
+                      type: string
+                    nonCompliantCertificates:
                       type: integer
-                    NonCompliantCertificatesList:
+                    nonCompliantCertificatesList:
                       additionalProperties:
                         description: Cert contains its related secret and when it expires
                         properties:
@@ -285,13 +279,11 @@ spec:
                             type: string
                         type: object
                       type: object
-                    message:
-                      type: string
                   type: object
                 description: map of namespaces to its compliancy details
                 type: object
               compliant:
-                description: Compliant, NonCompliant, UnkownCompliancy
+                description: Compliant, NonCompliant, UnknownCompliancy
                 type: string
             type: object
         type: object

--- a/pkg/addon/configpolicy/manifests/managedclusterchart/templates/policy.open-cluster-management.io_configurationpolicies_crd.yaml
+++ b/pkg/addon/configpolicy/manifests/managedclusterchart/templates/policy.open-cluster-management.io_configurationpolicies_crd.yaml
@@ -1,6 +1,8 @@
 # Copyright Contributors to the Open Cluster Management project
 
 {{- if semverCompare "< 1.16.0" .Capabilities.KubeVersion.Version }}
+
+---
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
@@ -231,6 +233,12 @@ spec:
   - name: v1
     served: true
     storage: true
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
 {{ else }}
 
 ---

--- a/pkg/addon/iampolicy/manifests/managedclusterchart/templates/policy.open-cluster-management.io_iampolicy_crd.yaml
+++ b/pkg/addon/iampolicy/manifests/managedclusterchart/templates/policy.open-cluster-management.io_iampolicy_crd.yaml
@@ -1,12 +1,14 @@
 # Copyright Contributors to the Open Cluster Management project
 
 {{- if semverCompare "< 1.16.0" .Capabilities.KubeVersion.Version }}
+
 ---
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
-  labels:
-    controller-tools.k8s.io: "1.0"
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.6.1
+  creationTimestamp: null
   name: iampolicies.policy.open-cluster-management.io
 spec:
   group: policy.open-cluster-management.io
@@ -61,7 +63,8 @@ spec:
               minimum: 1
               type: integer
             namespaceSelector:
-              description: Selecting a list of namespaces where the policy applies
+              description: Selecting a list of namespaces where the policy applies.
+                This field is obsolete and does not do anything.
               properties:
                 exclude:
                   items:
@@ -103,9 +106,10 @@ spec:
                     type: string
                   type: array
                 type: object
+              description: reason for non-compliancy
               type: object
             compliant:
-              description: ComplianceState shows the state of enforcement
+              description: Compliant, NonCompliant, UnknownCompliancy
               type: string
           type: object
       type: object
@@ -121,12 +125,13 @@ status:
   conditions: []
   storedVersions: []
 {{ else }}
+
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.5.0
+    controller-gen.kubebuilder.io/version: v0.6.1
   creationTimestamp: null
   name: iampolicies.policy.open-cluster-management.io
 spec:
@@ -182,7 +187,8 @@ spec:
                 minimum: 1
                 type: integer
               namespaceSelector:
-                description: Selecting a list of namespaces where the policy applies
+                description: Selecting a list of namespaces where the policy applies.
+                  This field is obsolete and does not do anything.
                 properties:
                   exclude:
                     items:
@@ -224,9 +230,10 @@ spec:
                       type: string
                     type: array
                   type: object
+                description: reason for non-compliancy
                 type: object
               compliant:
-                description: ComplianceState shows the state of enforcement
+                description: Compliant, NonCompliant, UnknownCompliancy
                 type: string
             type: object
         type: object

--- a/pkg/addon/policyframework/manifests/managedclusterchart/templates/policy.open-cluster-management.io_policies_crd.yaml
+++ b/pkg/addon/policyframework/manifests/managedclusterchart/templates/policy.open-cluster-management.io_policies_crd.yaml
@@ -1,12 +1,26 @@
 # Copyright Contributors to the Open Cluster Management project
 
-{{- if not .Values.onMulticlusterHub }}
 {{- if semverCompare "< 1.16.0" .Capabilities.KubeVersion.Version }}
+
+---
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.6.1
+  creationTimestamp: null
   name: policies.policy.open-cluster-management.io
 spec:
+  additionalPrinterColumns:
+  - JSONPath: .spec.remediationAction
+    name: Remediation action
+    type: string
+  - JSONPath: .status.compliant
+    name: Compliance state
+    type: string
+  - JSONPath: .metadata.creationTimestamp
+    name: Age
+    type: date
   group: policy.open-cluster-management.io
   names:
     kind: Policy
@@ -45,17 +59,18 @@ spec:
                 properties:
                   objectDefinition:
                     type: object
+                    x-kubernetes-preserve-unknown-fields: true
                 required:
-                  - objectDefinition
+                - objectDefinition
                 type: object
               type: array
             remediationAction:
               description: RemediationAction describes weather to enforce or inform
               enum:
-                - Inform
-                - inform
-                - Enforce
-                - enforce
+              - Inform
+              - inform
+              - Enforce
+              - enforce
               type: string
           required:
           - disabled
@@ -92,6 +107,7 @@ spec:
                     type: array
                   templateMeta:
                     type: object
+                    x-kubernetes-preserve-unknown-fields: true
                 type: object
               type: array
             placement:
@@ -109,9 +125,13 @@ spec:
                           type: string
                       type: object
                     type: array
+                  placement:
+                    type: string
                   placementBinding:
                     type: string
                   placementRule:
+                    type: string
+                  policySet:
                     type: string
                 type: object
               type: array
@@ -131,14 +151,23 @@ spec:
               type: array
           type: object
       required:
-        - metadata
-        - spec
+      - metadata
+      - spec
+      type: object
   version: v1
   versions:
   - name: v1
     served: true
     storage: true
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
 {{ else }}
+
+---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
@@ -268,6 +297,8 @@ spec:
                       type: string
                     placementRule:
                       type: string
+                    policySet:
+                      type: string
                   type: object
                 type: array
               status:
@@ -299,5 +330,4 @@ status:
     plural: ""
   conditions: []
   storedVersions: []
-{{- end }}
 {{- end }}


### PR DESCRIPTION
This should help keep the CRDs deployed by the addon-controller in sync
with the CRDs in the other repos. The v1beta1 CRDs are necessary for
older versions of kubernetes, but are not generated and stored in each
repo, so they must be generated specially.

The workflow defined here will not automatically update the CRDs, but
could be expanded in the future. For now it just runs nightly, but
doesn't alert anyone automatically.

Refs:
 - https://github.com/stolostron/backlog/issues/19031

Signed-off-by: Justin Kulikauskas <jkulikau@redhat.com>