### PR TITLE
Add managed cluster tests

### DIFF
--- a/.github/workflows/kind.yml
+++ b/.github/workflows/kind.yml
@@ -54,7 +54,7 @@ jobs:
       env:
         KIND_VERSION: ${{ matrix.kind }}
       run: |
-        make kind-deploy-controller
+        ./build/manage-clusters.sh
 
     - name: Unit and Integration Tests
       run: |
@@ -93,4 +93,4 @@ jobs:
     - name: Clean up cluster
       if: ${{ always() }}
       run: |
-        make kind-delete-cluster
+        DELETE_CLUSTERS="true" ./build/manage-clusters.sh

--- a/.gitignore
+++ b/.gitignore
@@ -14,5 +14,6 @@ bin/
 vendor/
 
 *.kubeconfig
+*.kubeconfig-internal
 coverage.out
 gosec.json

--- a/README.md
+++ b/README.md
@@ -88,6 +88,9 @@ starting a kind cluster, installing the
 [registration-operator](https://github.com/open-cluster-management-io/registration-operator), and
 importing a cluster.
 
+Alternatively, you can run `./build/manage-clusters.sh` to deploy a hub and a configurable number of
+managed clusters (defaults to one) using Kind.
+
 Before the addons can be successfully distributed to the managed cluster, the work-agent must be
 started. This usually happens automatically within 5 minutes of importing the managed cluster, and
 can be waited for programmatically with the `wait-for-work-agent` make target.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[comment]: # ( Copyright Contributors to the Open Cluster Management project )
+[comment]: # " Copyright Contributors to the Open Cluster Management project "
 
 # Governance Policy Addon Controller
 
@@ -10,14 +10,24 @@ Open Cluster Management - Governance Policy Addon Controller
 
 ## Description
 
-The governance policy addon controller manages installations of policy addons on managed clusters by using [ManifestWorks](https://github.com/open-cluster-management-io/api/blob/main/docs/manifestwork.md).
-The addons can be enabled, disabled, and configured via their `ManagedClusterAddon` resources.
-For more information on the addon framework, see the [addon-framework enhancement/design](https://github.com/open-cluster-management-io/enhancements/tree/main/enhancements/sig-architecture/8-addon-framework).
+The governance policy addon controller manages installations of policy addons on managed clusters by
+using
+[ManifestWorks](https://github.com/open-cluster-management-io/api/blob/main/docs/manifestwork.md).
+The addons can be enabled, disabled, and configured via their `ManagedClusterAddon` resources. For
+more information on the addon framework, see the
+[addon-framework enhancement/design](https://github.com/open-cluster-management-io/enhancements/tree/main/enhancements/sig-architecture/8-addon-framework).
 The addons managed by this controller are:
-- The "config-policy-controller" consisting of the [Configuration Policy Controller](https://github.com/stolostron/config-policy-controller).
-- The "cert-policy-controller" consisting of the [Certificate Policy Controller](https://github.com/stolostron/cert-policy-controller).
-- The "iam-policy-controller" consisting of the [IAM Policy Controller](https://github.com/stolostron/iam-policy-controller).
-- The "governance-policy-framework" consisting of the [Policy Spec Sync](https://github.com/stolostron/governance-policy-spec-sync), the [Policy Status Sync](https://github.com/stolostron/governance-policy-status-sync), and the [Policy Template Sync](https://github.com/stolostron/governance-policy-template-sync).
+
+- The "config-policy-controller" consisting of the
+  [Configuration Policy Controller](https://github.com/stolostron/config-policy-controller).
+- The "cert-policy-controller" consisting of the
+  [Certificate Policy Controller](https://github.com/stolostron/cert-policy-controller).
+- The "iam-policy-controller" consisting of the
+  [IAM Policy Controller](https://github.com/stolostron/iam-policy-controller).
+- The "governance-policy-framework" consisting of the
+  [Policy Spec Sync](https://github.com/stolostron/governance-policy-spec-sync), the
+  [Policy Status Sync](https://github.com/stolostron/governance-policy-status-sync), and the
+  [Policy Template Sync](https://github.com/stolostron/governance-policy-template-sync).
 
 Go to the [Contributing guide](CONTRIBUTING.md) to learn how to get involved.
 
@@ -30,18 +40,24 @@ Check the [Security guide](SECURITY.md) if you need to report a security issue.
 These instructions assume:
 
 - You have at least one running kubernetes cluster;
-- You have already followed instructions from [registration-operator](https://github.com/open-cluster-management-io/registration-operator) and installed OCM successfully;
+- You have already followed instructions from
+  [registration-operator](https://github.com/open-cluster-management-io/registration-operator) and
+  installed OCM successfully;
 - At least one managed cluster has been imported and accepted.
 
 ### Deploying the controller
 
-From the base of this repository, a default installation can be applied to the hub cluster with `kubectl apply -k config/default`.
-You might want to customize the namespace the controller is deployed to, or the specific image used by the controller.
-This can be done either by editing [config/default/kustomization.yaml](./config/default/kustomization.yaml) directly, or by using kustomize commands like `kustomize edit set namespace [mynamespace]` or `kustomize edit set image policy-addon-image=[myimage]`.
+From the base of this repository, a default installation can be applied to the hub cluster with
+`kubectl apply -k config/default`. You might want to customize the namespace the controller is
+deployed to, or the specific image used by the controller. This can be done either by editing
+[config/default/kustomization.yaml](./config/default/kustomization.yaml) directly, or by using
+kustomize commands like `kustomize edit set namespace [mynamespace]` or
+`kustomize edit set image policy-addon-image=[myimage]`.
 
 ### Deploying and Configuring an addon
 
-This example CR would deploy the Configuration Policy Controller to a managed cluster called `my-managed-cluster`:
+This example CR would deploy the Configuration Policy Controller to a managed cluster called
+`my-managed-cluster`:
 
 ```yaml
 apiVersion: addon.open-cluster-management.io/v1alpha1
@@ -53,32 +69,41 @@ spec:
   installNamespace: open-cluster-management-agent-addon
 ```
 
-To modify the image used by the Configuration Policy Controller on this managed cluster, you can add an annotation either by modifying and applying the YAML directly, or via a kubectl command like:
+To modify the image used by the Configuration Policy Controller on this managed cluster, you can add
+an annotation either by modifying and applying the YAML directly, or via a kubectl command like:
 
 ```shell
 kubectl -n my-managed-cluster annotate managedclusteraddon config-policy-controller addon.open-cluster-management.io/values='{"global":{"imageOverrides":{"config_policy_controller":"quay.io/my-repo/my-configpolicy:imagetag"}}}'
 ```
 
-Any values in the [Helm chart's values.yaml](./pkg/addon/configpolicy/manifests/managedclusterchart/values.yaml) can be modified in this way.
+Any values in the
+[Helm chart's values.yaml](./pkg/addon/configpolicy/manifests/managedclusterchart/values.yaml) can
+be modified in this way.
 
 ## Getting Started - Development
 
-To set up a local [KinD](https://kind.sigs.k8s.io/) cluster for development, you'll need to install `kind`.
-Then you can use the `kind-deploy-controller` make target to set everything up, including starting a kind cluster, installing the [registration-operator](https://github.com/open-cluster-management-io/registration-operator), and importing a cluster.
+To set up a local [KinD](https://kind.sigs.k8s.io/) cluster for development, you'll need to install
+`kind`. Then you can use the `kind-deploy-controller` make target to set everything up, including
+starting a kind cluster, installing the
+[registration-operator](https://github.com/open-cluster-management-io/registration-operator), and
+importing a cluster.
 
-Before the addons can be successfully distributed to the managed cluster, the work-agent must be started.
-This usually happens automatically within 5 minutes of importing the managed cluster, and can be waited for programmatically with the `wait-for-work-agent` make target.
+Before the addons can be successfully distributed to the managed cluster, the work-agent must be
+started. This usually happens automatically within 5 minutes of importing the managed cluster, and
+can be waited for programmatically with the `wait-for-work-agent` make target.
 
 ### Deploying changes
 
-Two make targets are used to update the controller running in the kind clusters with any local changes.
-The `kind-load-image` target will re-build the image, and load it into the kind cluster.
-The `kind-regenerate-controller` target will update the deployment manifests with any local changes (including RBAC changes), and restart the controller on the cluster to update it.
+Two make targets are used to update the controller running in the kind clusters with any local
+changes. The `kind-load-image` target will re-build the image, and load it into the kind cluster.
+The `kind-regenerate-controller` target will update the deployment manifests with any local changes
+(including RBAC changes), and restart the controller on the cluster to update it.
 
 ### Running Tests
 
-The e2e tests are intended to be run against a `kind` cluster.
-After setting one up with the steps above (and waiting for the work-agent), the tests can be run with the `e2e-test` make target.
+The e2e tests are intended to be run against a `kind` cluster. After setting one up with the steps
+above (and waiting for the work-agent), the tests can be run with the `e2e-test` make target.
+
 <!---
 Date: 03/04/2022
 -->

--- a/build/common/Makefile.common.mk
+++ b/build/common/Makefile.common.mk
@@ -42,7 +42,7 @@ lint-scripts:
 	@${FINDFILES} -name '*.sh' -print0 | ${XARGS} shellcheck -e SC2001
 
 lint-yaml:
-	@${FINDFILES} \( -name '*.yml' -o -name '*.yaml' \) -print0 | ${XARGS} grep -L -e "{{" | ${CLEANXARGS} yamllint -c ./build/common/config/.yamllint.yml
+	@${FINDFILES} \( -name '*.yml' -o -name '*.yaml' \) -print0 | { ${XARGS} grep -L -e "{{" || test $$? = 1; } | ${CLEANXARGS} yamllint -c ./build/common/config/.yamllint.yml
 
 lint-copyright-banner:
 	@${FINDFILES} \( -name '*.go' -o -name '*.cc' -o -name '*.h' -o -name '*.proto' -o -name '*.py' -o -name '*.sh' \) \( ! \( -name '*.gen.go' -o -name '*.pb.go' -o -name '*_pb2.py' \) \) -print0 |\

--- a/build/manage-clusters.sh
+++ b/build/manage-clusters.sh
@@ -1,0 +1,34 @@
+#! /bin/bash
+
+# Number of managed clusters
+MANAGED_CLUSTER_COUNT=${MANAGED_CLUSTER_COUNT:-1}
+if [[ -n "${MANAGED_CLUSTER_COUNT//[0-9]}" ]] || [[ "${MANAGED_CLUSTER_COUNT}" == "0" ]]; then
+  echo "error: provided MANAGED_CLUSTER_COUNT is not a nonzero integer"
+  exit 1
+fi
+KIND_PREFIX=${KIND_PREFIX:-"policy-addon-ctrl"}
+CLUSTER_PREFIX=${CLUSTER_PREFIX:-"cluster"}
+
+export KIND_NAME="${KIND_PREFIX}1"
+export MANAGED_CLUSTER_NAME="${CLUSTER_PREFIX}1"
+# Deploy the hub cluster as cluster1
+if [ "${DELETE_CLUSTERS}" == "true" ]; then
+  make kind-delete-cluster
+else
+  make kind-deploy-controller
+fi
+
+# Deploy a variable number of managed clusters starting with cluster2
+for i in $(seq 2 $((MANAGED_CLUSTER_COUNT+1))); do
+  export KIND_NAME="${KIND_PREFIX}${i}"
+  export MANAGED_CLUSTER_NAME="${CLUSTER_PREFIX}${i}"
+  export HUB_KUBECONFIG="${PWD}/${KIND_PREFIX}1.kubeconfig-internal"
+  if [ "${DELETE_CLUSTERS}" == "true" ]; then
+    make kind-delete-cluster
+  else
+    make kind-deploy-registration-operator-managed
+    # Approval takes place on the hub
+    export KIND_NAME="${KIND_PREFIX}1"
+    make kind-approve-cluster
+  fi
+done

--- a/test/e2e/case1_framework_deployment_test.go
+++ b/test/e2e/case1_framework_deployment_test.go
@@ -16,7 +16,7 @@ const (
 
 var _ = Describe("Test framework deployment", func() {
 	It("should create the default framework deployment on the managed cluster", func() {
-		Kubectl("apply", "-f", case1ManagedClusterAddOnCR)
+		Kubectl("apply", "-n", "cluster1", "-f", case1ManagedClusterAddOnCR)
 		deploy := GetWithTimeout(clientDynamic, gvrDeployment, case1FrameworkDeploymentName, addonNamespace, true, 30)
 		Expect(deploy).NotTo(BeNil())
 
@@ -51,18 +51,18 @@ var _ = Describe("Test framework deployment", func() {
 		}, 240, 1).Should(Equal(true))
 	})
 	It("should remove the framework deployment when the ManagedClusterAddOn CR is removed", func() {
-		Kubectl("delete", "-f", case1ManagedClusterAddOnCR)
+		Kubectl("delete", "-n", "cluster1", "-f", case1ManagedClusterAddOnCR)
 		deploy := GetWithTimeout(clientDynamic, gvrDeployment, case1FrameworkDeploymentName, addonNamespace, false, 30)
 		Expect(deploy).To(BeNil())
 	})
 	It("should deploy with 2 containers if onManagedClusterHub is set in helm values annotation", func() {
 		By("deploying the default framework managedclusteraddon")
-		Kubectl("apply", "-f", case1ManagedClusterAddOnCR)
+		Kubectl("apply", "-n", "cluster1", "-f", case1ManagedClusterAddOnCR)
 		deploy := GetWithTimeout(clientDynamic, gvrDeployment, case1FrameworkDeploymentName, addonNamespace, true, 30)
 		Expect(deploy).NotTo(BeNil())
 
 		By("annotating the framework managedclusteraddon with helm values")
-		Kubectl("annotate", "-f", case1ManagedClusterAddOnCR,
+		Kubectl("annotate", "-n", "cluster1", "-f", case1ManagedClusterAddOnCR,
 			"addon.open-cluster-management.io/values={\"onMulticlusterHub\":true}")
 
 		Eventually(func() int {
@@ -84,18 +84,18 @@ var _ = Describe("Test framework deployment", func() {
 		}, 240, 1).Should(Equal(true))
 
 		By("deleting the managedclusteraddon")
-		Kubectl("delete", "-f", case1ManagedClusterAddOnCR)
+		Kubectl("delete", "-n", "cluster1", "-f", case1ManagedClusterAddOnCR)
 		deploy = GetWithTimeout(clientDynamic, gvrDeployment, case1FrameworkDeploymentName, addonNamespace, false, 30)
 		Expect(deploy).To(BeNil())
 	})
 	It("should deploy with 2 containers if onManagedClusterHub is set in the custom annotation", func() {
 		By("deploying the default framework managedclusteraddon")
-		Kubectl("apply", "-f", case1ManagedClusterAddOnCR)
+		Kubectl("apply", "-n", "cluster1", "-f", case1ManagedClusterAddOnCR)
 		deploy := GetWithTimeout(clientDynamic, gvrDeployment, case1FrameworkDeploymentName, addonNamespace, true, 30)
 		Expect(deploy).NotTo(BeNil())
 
 		By("annotating the framework managedclusteraddon with helm values")
-		Kubectl("annotate", "-f", case1ManagedClusterAddOnCR,
+		Kubectl("annotate", "-n", "cluster1", "-f", case1ManagedClusterAddOnCR,
 			"addon.open-cluster-management.io/on-multicluster-hub=true")
 
 		Eventually(func() int {
@@ -117,7 +117,7 @@ var _ = Describe("Test framework deployment", func() {
 		}, 240, 1).Should(Equal(true))
 
 		By("deleting the managedclusteraddon")
-		Kubectl("delete", "-f", case1ManagedClusterAddOnCR)
+		Kubectl("delete", "-n", "cluster1", "-f", case1ManagedClusterAddOnCR)
 		deploy = GetWithTimeout(clientDynamic, gvrDeployment, case1FrameworkDeploymentName, addonNamespace, false, 30)
 		Expect(deploy).To(BeNil())
 	})

--- a/test/e2e/case1_framework_deployment_test.go
+++ b/test/e2e/case1_framework_deployment_test.go
@@ -15,110 +15,173 @@ const (
 )
 
 var _ = Describe("Test framework deployment", func() {
-	It("should create the default framework deployment on the managed cluster", func() {
-		Kubectl("apply", "-n", "cluster1", "-f", case1ManagedClusterAddOnCR)
-		deploy := GetWithTimeout(clientDynamic, gvrDeployment, case1FrameworkDeploymentName, addonNamespace, true, 30)
-		Expect(deploy).NotTo(BeNil())
+	It("should create the default framework deployment", func() {
+		for _, cluster := range managedClusterList {
+			By(cluster.clusterType + " " + cluster.clusterName + ": deploying the default framework managedclusteraddon")
+			Kubectl("apply", "-n", cluster.clusterName, "-f", case1ManagedClusterAddOnCR)
+			deploy := GetWithTimeout(cluster.clusterClient, gvrDeployment, case1FrameworkDeploymentName, addonNamespace, true, 30)
+			Expect(deploy).NotTo(BeNil())
 
-		By("checking the number of containers in the deployment")
-		Eventually(func() int {
-			deploy := GetWithTimeout(clientDynamic, gvrDeployment,
-				case1FrameworkDeploymentName, addonNamespace, true, 30)
-			spec := deploy.Object["spec"].(map[string]interface{})["template"].(map[string]interface{})["spec"]
-			containers := spec.(map[string]interface{})["containers"]
+			By(cluster.clusterType + " " + cluster.clusterName + ": checking the number of containers in the deployment")
+			Eventually(func() int {
+				deploy = GetWithTimeout(cluster.clusterClient, gvrDeployment,
+					case1FrameworkDeploymentName, addonNamespace, true, 30)
+				spec := deploy.Object["spec"].(map[string]interface{})["template"].(map[string]interface{})["spec"]
+				containers := spec.(map[string]interface{})["containers"]
 
-			return len(containers.([]interface{}))
-		}, 60, 1).Should(Equal(3))
-	})
-	It("should have a framework pod that is running", func() {
-		Eventually(func() bool {
-			opts := metav1.ListOptions{
-				LabelSelector: case1FrameworkPodSelector,
-			}
-			pods := ListWithTimeoutByNamespace(clientDynamic, gvrPod, opts, addonNamespace, 1, true, 30)
-			phase := pods.Items[0].Object["status"].(map[string]interface{})["phase"]
+				return len(containers.([]interface{}))
+			}, 60, 1).Should(Equal(3))
 
-			return phase.(string) == "Running"
-		}, 60, 1).Should(Equal(true))
-	})
-	It("should show the framework managedclusteraddon as available", func() {
-		Eventually(func() bool {
-			addon := GetWithTimeout(
-				clientDynamic, gvrManagedClusterAddOn, case1FrameworkDeploymentName, "cluster1", true, 30,
-			)
+			By(cluster.clusterType + " " + cluster.clusterName + ": verifying all replicas in framework deployment are available")
+			Eventually(func() bool {
+				deploy = GetWithTimeout(cluster.clusterClient, gvrDeployment, case1FrameworkDeploymentName, addonNamespace, true, 30)
+				status := deploy.Object["status"]
+				replicas := status.(map[string]interface{})["replicas"]
+				availableReplicas := status.(map[string]interface{})["availableReplicas"]
 
-			return getAddonStatus(addon)
-		}, 240, 1).Should(Equal(true))
+				return (availableReplicas != nil) && replicas.(int64) == availableReplicas.(int64)
+			}, 240, 1).Should(Equal(true))
+
+			By(cluster.clusterType + " " + cluster.clusterName + ": verifying a framework pod is running")
+			Eventually(func() bool {
+				opts := metav1.ListOptions{
+					LabelSelector: case1FrameworkPodSelector,
+				}
+				pods := ListWithTimeoutByNamespace(cluster.clusterClient, gvrPod, opts, addonNamespace, 1, true, 30)
+				phase := pods.Items[0].Object["status"].(map[string]interface{})["phase"]
+
+				return phase.(string) == "Running"
+			}, 60, 1).Should(Equal(true))
+
+			By(cluster.clusterType + " " + cluster.clusterName + ": showing the framework managedclusteraddon as available")
+			Eventually(func() bool {
+				addon := GetWithTimeout(
+					clientDynamic, gvrManagedClusterAddOn, case1FrameworkDeploymentName, cluster.clusterName, true, 30,
+				)
+
+				return getAddonStatus(addon)
+			}, 240, 1).Should(Equal(true))
+
+			By(cluster.clusterType + " " + cluster.clusterName + ": removing the framework deployment when the ManagedClusterAddOn CR is removed")
+			Kubectl("delete", "-n", cluster.clusterName, "-f", case1ManagedClusterAddOnCR)
+			deploy = GetWithTimeout(cluster.clusterClient, gvrDeployment, case1FrameworkDeploymentName, addonNamespace, false, 30)
+			Expect(deploy).To(BeNil())
+		}
 	})
-	It("should remove the framework deployment when the ManagedClusterAddOn CR is removed", func() {
-		Kubectl("delete", "-n", "cluster1", "-f", case1ManagedClusterAddOnCR)
-		deploy := GetWithTimeout(clientDynamic, gvrDeployment, case1FrameworkDeploymentName, addonNamespace, false, 30)
-		Expect(deploy).To(BeNil())
-	})
+
 	It("should deploy with 2 containers if onManagedClusterHub is set in helm values annotation", func() {
-		By("deploying the default framework managedclusteraddon")
-		Kubectl("apply", "-n", "cluster1", "-f", case1ManagedClusterAddOnCR)
-		deploy := GetWithTimeout(clientDynamic, gvrDeployment, case1FrameworkDeploymentName, addonNamespace, true, 30)
-		Expect(deploy).NotTo(BeNil())
+		for _, cluster := range managedClusterList {
+			By(cluster.clusterType + " " + cluster.clusterName + ": deploying the default framework managedclusteraddon")
+			Kubectl("apply", "-n", cluster.clusterName, "-f", case1ManagedClusterAddOnCR)
+			deploy := GetWithTimeout(cluster.clusterClient, gvrDeployment, case1FrameworkDeploymentName, addonNamespace, true, 30)
+			Expect(deploy).NotTo(BeNil())
 
-		By("annotating the framework managedclusteraddon with helm values")
-		Kubectl("annotate", "-n", "cluster1", "-f", case1ManagedClusterAddOnCR,
-			"addon.open-cluster-management.io/values={\"onMulticlusterHub\":true}")
+			By(cluster.clusterType + " " + cluster.clusterName + ": annotating the framework managedclusteraddon with helm values")
+			Kubectl("annotate", "-n", cluster.clusterName, "-f", case1ManagedClusterAddOnCR,
+				"addon.open-cluster-management.io/values={\"onMulticlusterHub\":true}")
 
-		Eventually(func() int {
-			deploy := GetWithTimeout(clientDynamic, gvrDeployment,
-				case1FrameworkDeploymentName, addonNamespace, true, 30)
-			spec := deploy.Object["spec"].(map[string]interface{})["template"].(map[string]interface{})["spec"]
-			containers := spec.(map[string]interface{})["containers"]
+			By(cluster.clusterType + " " + cluster.clusterName + ": checking the number of containers in the deployment")
+			Eventually(func() int {
+				deploy = GetWithTimeout(cluster.clusterClient, gvrDeployment,
+					case1FrameworkDeploymentName, addonNamespace, true, 30)
+				spec := deploy.Object["spec"].(map[string]interface{})["template"].(map[string]interface{})["spec"]
+				containers := spec.(map[string]interface{})["containers"]
 
-			return len(containers.([]interface{}))
-		}, 60, 1).Should(Equal(2))
+				return len(containers.([]interface{}))
+			}, 60, 1).Should(Equal(2))
 
-		By("showing the framework managedclusteraddon as available")
-		Eventually(func() bool {
-			addon := GetWithTimeout(
-				clientDynamic, gvrManagedClusterAddOn, case1FrameworkDeploymentName, "cluster1", true, 30,
-			)
+			By(cluster.clusterType + " " + cluster.clusterName + ": verifying all replicas in framework deployment are available")
+			Eventually(func() bool {
+				deploy = GetWithTimeout(cluster.clusterClient, gvrDeployment, case1FrameworkDeploymentName, addonNamespace, true, 30)
+				status := deploy.Object["status"]
+				replicas := status.(map[string]interface{})["replicas"]
+				availableReplicas := status.(map[string]interface{})["availableReplicas"]
 
-			return getAddonStatus(addon)
-		}, 240, 1).Should(Equal(true))
+				return (availableReplicas != nil) && replicas.(int64) == availableReplicas.(int64)
+			}, 240, 1).Should(Equal(true))
 
-		By("deleting the managedclusteraddon")
-		Kubectl("delete", "-n", "cluster1", "-f", case1ManagedClusterAddOnCR)
-		deploy = GetWithTimeout(clientDynamic, gvrDeployment, case1FrameworkDeploymentName, addonNamespace, false, 30)
-		Expect(deploy).To(BeNil())
+			By(cluster.clusterType + " " + cluster.clusterName + ": verifying a framework pod is running")
+			Eventually(func() bool {
+				opts := metav1.ListOptions{
+					LabelSelector: case1FrameworkPodSelector,
+				}
+				pods := ListWithTimeoutByNamespace(cluster.clusterClient, gvrPod, opts, addonNamespace, 1, true, 30)
+				phase := pods.Items[0].Object["status"].(map[string]interface{})["phase"]
+
+				return phase.(string) == "Running"
+			}, 60, 1).Should(Equal(true))
+
+			By(cluster.clusterType + " " + cluster.clusterName + ": showing the framework managedclusteraddon as available")
+			Eventually(func() bool {
+				addon := GetWithTimeout(
+					clientDynamic, gvrManagedClusterAddOn, case1FrameworkDeploymentName, cluster.clusterName, true, 30,
+				)
+
+				return getAddonStatus(addon)
+			}, 240, 1).Should(Equal(true))
+
+			By(cluster.clusterType + " " + cluster.clusterName + ": deleting the managedclusteraddon")
+			Kubectl("delete", "-n", cluster.clusterName, "-f", case1ManagedClusterAddOnCR)
+			deploy = GetWithTimeout(cluster.clusterClient, gvrDeployment, case1FrameworkDeploymentName, addonNamespace, false, 30)
+			Expect(deploy).To(BeNil())
+		}
 	})
+
 	It("should deploy with 2 containers if onManagedClusterHub is set in the custom annotation", func() {
-		By("deploying the default framework managedclusteraddon")
-		Kubectl("apply", "-n", "cluster1", "-f", case1ManagedClusterAddOnCR)
-		deploy := GetWithTimeout(clientDynamic, gvrDeployment, case1FrameworkDeploymentName, addonNamespace, true, 30)
-		Expect(deploy).NotTo(BeNil())
+		for _, cluster := range managedClusterList {
+			By(cluster.clusterType + " " + cluster.clusterName + ": deploying the default framework managedclusteraddon")
+			Kubectl("apply", "-n", cluster.clusterName, "-f", case1ManagedClusterAddOnCR)
+			deploy := GetWithTimeout(cluster.clusterClient, gvrDeployment, case1FrameworkDeploymentName, addonNamespace, true, 30)
+			Expect(deploy).NotTo(BeNil())
 
-		By("annotating the framework managedclusteraddon with helm values")
-		Kubectl("annotate", "-n", "cluster1", "-f", case1ManagedClusterAddOnCR,
-			"addon.open-cluster-management.io/on-multicluster-hub=true")
+			By(cluster.clusterType + " " + cluster.clusterName + ": annotating the framework managedclusteraddon with custom annotation")
+			Kubectl("annotate", "-n", cluster.clusterName, "-f", case1ManagedClusterAddOnCR,
+				"addon.open-cluster-management.io/on-multicluster-hub=true")
 
-		Eventually(func() int {
-			deploy := GetWithTimeout(clientDynamic, gvrDeployment,
-				case1FrameworkDeploymentName, addonNamespace, true, 30)
-			spec := deploy.Object["spec"].(map[string]interface{})["template"].(map[string]interface{})["spec"]
-			containers := spec.(map[string]interface{})["containers"]
+			By(cluster.clusterType + " " + cluster.clusterName + ": checking the number of containers in the deployment")
+			Eventually(func() int {
+				deploy = GetWithTimeout(cluster.clusterClient, gvrDeployment,
+					case1FrameworkDeploymentName, addonNamespace, true, 30)
+				spec := deploy.Object["spec"].(map[string]interface{})["template"].(map[string]interface{})["spec"]
+				containers := spec.(map[string]interface{})["containers"]
 
-			return len(containers.([]interface{}))
-		}, 60, 1).Should(Equal(2))
+				return len(containers.([]interface{}))
+			}, 60, 1).Should(Equal(2))
 
-		By("showing the framework managedclusteraddon as available")
-		Eventually(func() bool {
-			addon := GetWithTimeout(
-				clientDynamic, gvrManagedClusterAddOn, case1FrameworkDeploymentName, "cluster1", true, 30,
-			)
+			By(cluster.clusterType + " " + cluster.clusterName + ": verifying all replicas in framework deployment are available")
+			Eventually(func() bool {
+				deploy = GetWithTimeout(cluster.clusterClient, gvrDeployment, case1FrameworkDeploymentName, addonNamespace, true, 30)
+				status := deploy.Object["status"]
+				replicas := status.(map[string]interface{})["replicas"]
+				availableReplicas := status.(map[string]interface{})["availableReplicas"]
 
-			return getAddonStatus(addon)
-		}, 240, 1).Should(Equal(true))
+				return (availableReplicas != nil) && replicas.(int64) == availableReplicas.(int64)
+			}, 240, 1).Should(Equal(true))
 
-		By("deleting the managedclusteraddon")
-		Kubectl("delete", "-n", "cluster1", "-f", case1ManagedClusterAddOnCR)
-		deploy = GetWithTimeout(clientDynamic, gvrDeployment, case1FrameworkDeploymentName, addonNamespace, false, 30)
-		Expect(deploy).To(BeNil())
+			By(cluster.clusterType + " " + cluster.clusterName + ": verifying a framework pod is running")
+			Eventually(func() bool {
+				opts := metav1.ListOptions{
+					LabelSelector: case1FrameworkPodSelector,
+				}
+				pods := ListWithTimeoutByNamespace(cluster.clusterClient, gvrPod, opts, addonNamespace, 1, true, 30)
+				phase := pods.Items[0].Object["status"].(map[string]interface{})["phase"]
+
+				return phase.(string) == "Running"
+			}, 60, 1).Should(Equal(true))
+
+			By(cluster.clusterType + " " + cluster.clusterName + ": showing the framework managedclusteraddon as available")
+			Eventually(func() bool {
+				addon := GetWithTimeout(
+					clientDynamic, gvrManagedClusterAddOn, case1FrameworkDeploymentName, cluster.clusterName, true, 30,
+				)
+
+				return getAddonStatus(addon)
+			}, 240, 1).Should(Equal(true))
+
+			By(cluster.clusterType + " " + cluster.clusterName + ": deleting the managedclusteraddon")
+			Kubectl("delete", "-n", cluster.clusterName, "-f", case1ManagedClusterAddOnCR)
+			deploy = GetWithTimeout(cluster.clusterClient, gvrDeployment, case1FrameworkDeploymentName, addonNamespace, false, 30)
+			Expect(deploy).To(BeNil())
+		}
 	})
 })

--- a/test/e2e/case1_framework_deployment_test.go
+++ b/test/e2e/case1_framework_deployment_test.go
@@ -17,12 +17,16 @@ const (
 var _ = Describe("Test framework deployment", func() {
 	It("should create the default framework deployment", func() {
 		for _, cluster := range managedClusterList {
-			By(cluster.clusterType + " " + cluster.clusterName + ": deploying the default framework managedclusteraddon")
+			By(cluster.clusterType + " " + cluster.clusterName +
+				": deploying the default framework managedclusteraddon")
 			Kubectl("apply", "-n", cluster.clusterName, "-f", case1ManagedClusterAddOnCR)
-			deploy := GetWithTimeout(cluster.clusterClient, gvrDeployment, case1FrameworkDeploymentName, addonNamespace, true, 30)
+			deploy := GetWithTimeout(
+				cluster.clusterClient, gvrDeployment, case1FrameworkDeploymentName, addonNamespace, true, 30,
+			)
 			Expect(deploy).NotTo(BeNil())
 
-			By(cluster.clusterType + " " + cluster.clusterName + ": checking the number of containers in the deployment")
+			By(cluster.clusterType + " " + cluster.clusterName +
+				": checking the number of containers in the deployment")
 			Eventually(func() int {
 				deploy = GetWithTimeout(cluster.clusterClient, gvrDeployment,
 					case1FrameworkDeploymentName, addonNamespace, true, 30)
@@ -32,9 +36,12 @@ var _ = Describe("Test framework deployment", func() {
 				return len(containers.([]interface{}))
 			}, 60, 1).Should(Equal(3))
 
-			By(cluster.clusterType + " " + cluster.clusterName + ": verifying all replicas in framework deployment are available")
+			By(cluster.clusterType + " " + cluster.clusterName +
+				": verifying all replicas in framework deployment are available")
 			Eventually(func() bool {
-				deploy = GetWithTimeout(cluster.clusterClient, gvrDeployment, case1FrameworkDeploymentName, addonNamespace, true, 30)
+				deploy = GetWithTimeout(
+					cluster.clusterClient, gvrDeployment, case1FrameworkDeploymentName, addonNamespace, true, 30,
+				)
 				status := deploy.Object["status"]
 				replicas := status.(map[string]interface{})["replicas"]
 				availableReplicas := status.(map[string]interface{})["availableReplicas"]
@@ -53,7 +60,8 @@ var _ = Describe("Test framework deployment", func() {
 				return phase.(string) == "Running"
 			}, 60, 1).Should(Equal(true))
 
-			By(cluster.clusterType + " " + cluster.clusterName + ": showing the framework managedclusteraddon as available")
+			By(cluster.clusterType + " " + cluster.clusterName +
+				": showing the framework managedclusteraddon as available")
 			Eventually(func() bool {
 				addon := GetWithTimeout(
 					clientDynamic, gvrManagedClusterAddOn, case1FrameworkDeploymentName, cluster.clusterName, true, 30,
@@ -62,25 +70,33 @@ var _ = Describe("Test framework deployment", func() {
 				return getAddonStatus(addon)
 			}, 240, 1).Should(Equal(true))
 
-			By(cluster.clusterType + " " + cluster.clusterName + ": removing the framework deployment when the ManagedClusterAddOn CR is removed")
+			By(cluster.clusterType + " " + cluster.clusterName +
+				": removing the framework deployment when the ManagedClusterAddOn CR is removed")
 			Kubectl("delete", "-n", cluster.clusterName, "-f", case1ManagedClusterAddOnCR)
-			deploy = GetWithTimeout(cluster.clusterClient, gvrDeployment, case1FrameworkDeploymentName, addonNamespace, false, 30)
+			deploy = GetWithTimeout(
+				cluster.clusterClient, gvrDeployment, case1FrameworkDeploymentName, addonNamespace, false, 30,
+			)
 			Expect(deploy).To(BeNil())
 		}
 	})
 
 	It("should deploy with 2 containers if onManagedClusterHub is set in helm values annotation", func() {
 		for _, cluster := range managedClusterList {
-			By(cluster.clusterType + " " + cluster.clusterName + ": deploying the default framework managedclusteraddon")
+			By(cluster.clusterType + " " + cluster.clusterName +
+				": deploying the default framework managedclusteraddon")
 			Kubectl("apply", "-n", cluster.clusterName, "-f", case1ManagedClusterAddOnCR)
-			deploy := GetWithTimeout(cluster.clusterClient, gvrDeployment, case1FrameworkDeploymentName, addonNamespace, true, 30)
+			deploy := GetWithTimeout(
+				cluster.clusterClient, gvrDeployment, case1FrameworkDeploymentName, addonNamespace, true, 30,
+			)
 			Expect(deploy).NotTo(BeNil())
 
-			By(cluster.clusterType + " " + cluster.clusterName + ": annotating the framework managedclusteraddon with helm values")
+			By(cluster.clusterType + " " + cluster.clusterName +
+				": annotating the framework managedclusteraddon with helm values")
 			Kubectl("annotate", "-n", cluster.clusterName, "-f", case1ManagedClusterAddOnCR,
 				"addon.open-cluster-management.io/values={\"onMulticlusterHub\":true}")
 
-			By(cluster.clusterType + " " + cluster.clusterName + ": checking the number of containers in the deployment")
+			By(cluster.clusterType + " " + cluster.clusterName +
+				": checking the number of containers in the deployment")
 			Eventually(func() int {
 				deploy = GetWithTimeout(cluster.clusterClient, gvrDeployment,
 					case1FrameworkDeploymentName, addonNamespace, true, 30)
@@ -90,9 +106,12 @@ var _ = Describe("Test framework deployment", func() {
 				return len(containers.([]interface{}))
 			}, 60, 1).Should(Equal(2))
 
-			By(cluster.clusterType + " " + cluster.clusterName + ": verifying all replicas in framework deployment are available")
+			By(cluster.clusterType + " " + cluster.clusterName +
+				": verifying all replicas in framework deployment are available")
 			Eventually(func() bool {
-				deploy = GetWithTimeout(cluster.clusterClient, gvrDeployment, case1FrameworkDeploymentName, addonNamespace, true, 30)
+				deploy = GetWithTimeout(
+					cluster.clusterClient, gvrDeployment, case1FrameworkDeploymentName, addonNamespace, true, 30,
+				)
 				status := deploy.Object["status"]
 				replicas := status.(map[string]interface{})["replicas"]
 				availableReplicas := status.(map[string]interface{})["availableReplicas"]
@@ -111,7 +130,8 @@ var _ = Describe("Test framework deployment", func() {
 				return phase.(string) == "Running"
 			}, 60, 1).Should(Equal(true))
 
-			By(cluster.clusterType + " " + cluster.clusterName + ": showing the framework managedclusteraddon as available")
+			By(cluster.clusterType + " " + cluster.clusterName +
+				": showing the framework managedclusteraddon as available")
 			Eventually(func() bool {
 				addon := GetWithTimeout(
 					clientDynamic, gvrManagedClusterAddOn, case1FrameworkDeploymentName, cluster.clusterName, true, 30,
@@ -122,23 +142,30 @@ var _ = Describe("Test framework deployment", func() {
 
 			By(cluster.clusterType + " " + cluster.clusterName + ": deleting the managedclusteraddon")
 			Kubectl("delete", "-n", cluster.clusterName, "-f", case1ManagedClusterAddOnCR)
-			deploy = GetWithTimeout(cluster.clusterClient, gvrDeployment, case1FrameworkDeploymentName, addonNamespace, false, 30)
+			deploy = GetWithTimeout(
+				cluster.clusterClient, gvrDeployment, case1FrameworkDeploymentName, addonNamespace, false, 30,
+			)
 			Expect(deploy).To(BeNil())
 		}
 	})
 
 	It("should deploy with 2 containers if onManagedClusterHub is set in the custom annotation", func() {
 		for _, cluster := range managedClusterList {
-			By(cluster.clusterType + " " + cluster.clusterName + ": deploying the default framework managedclusteraddon")
+			By(cluster.clusterType + " " + cluster.clusterName +
+				": deploying the default framework managedclusteraddon")
 			Kubectl("apply", "-n", cluster.clusterName, "-f", case1ManagedClusterAddOnCR)
-			deploy := GetWithTimeout(cluster.clusterClient, gvrDeployment, case1FrameworkDeploymentName, addonNamespace, true, 30)
+			deploy := GetWithTimeout(
+				cluster.clusterClient, gvrDeployment, case1FrameworkDeploymentName, addonNamespace, true, 30,
+			)
 			Expect(deploy).NotTo(BeNil())
 
-			By(cluster.clusterType + " " + cluster.clusterName + ": annotating the framework managedclusteraddon with custom annotation")
+			By(cluster.clusterType + " " + cluster.clusterName +
+				": annotating the framework managedclusteraddon with custom annotation")
 			Kubectl("annotate", "-n", cluster.clusterName, "-f", case1ManagedClusterAddOnCR,
 				"addon.open-cluster-management.io/on-multicluster-hub=true")
 
-			By(cluster.clusterType + " " + cluster.clusterName + ": checking the number of containers in the deployment")
+			By(cluster.clusterType + " " + cluster.clusterName +
+				": checking the number of containers in the deployment")
 			Eventually(func() int {
 				deploy = GetWithTimeout(cluster.clusterClient, gvrDeployment,
 					case1FrameworkDeploymentName, addonNamespace, true, 30)
@@ -148,9 +175,12 @@ var _ = Describe("Test framework deployment", func() {
 				return len(containers.([]interface{}))
 			}, 60, 1).Should(Equal(2))
 
-			By(cluster.clusterType + " " + cluster.clusterName + ": verifying all replicas in framework deployment are available")
+			By(cluster.clusterType + " " + cluster.clusterName +
+				": verifying all replicas in framework deployment are available")
 			Eventually(func() bool {
-				deploy = GetWithTimeout(cluster.clusterClient, gvrDeployment, case1FrameworkDeploymentName, addonNamespace, true, 30)
+				deploy = GetWithTimeout(
+					cluster.clusterClient, gvrDeployment, case1FrameworkDeploymentName, addonNamespace, true, 30,
+				)
 				status := deploy.Object["status"]
 				replicas := status.(map[string]interface{})["replicas"]
 				availableReplicas := status.(map[string]interface{})["availableReplicas"]
@@ -169,7 +199,8 @@ var _ = Describe("Test framework deployment", func() {
 				return phase.(string) == "Running"
 			}, 60, 1).Should(Equal(true))
 
-			By(cluster.clusterType + " " + cluster.clusterName + ": showing the framework managedclusteraddon as available")
+			By(cluster.clusterType + " " + cluster.clusterName +
+				": showing the framework managedclusteraddon as available")
 			Eventually(func() bool {
 				addon := GetWithTimeout(
 					clientDynamic, gvrManagedClusterAddOn, case1FrameworkDeploymentName, cluster.clusterName, true, 30,
@@ -180,7 +211,9 @@ var _ = Describe("Test framework deployment", func() {
 
 			By(cluster.clusterType + " " + cluster.clusterName + ": deleting the managedclusteraddon")
 			Kubectl("delete", "-n", cluster.clusterName, "-f", case1ManagedClusterAddOnCR)
-			deploy = GetWithTimeout(cluster.clusterClient, gvrDeployment, case1FrameworkDeploymentName, addonNamespace, false, 30)
+			deploy = GetWithTimeout(
+				cluster.clusterClient, gvrDeployment, case1FrameworkDeploymentName, addonNamespace, false, 30,
+			)
 			Expect(deploy).To(BeNil())
 		}
 	})

--- a/test/e2e/case2_config_deployment_test.go
+++ b/test/e2e/case2_config_deployment_test.go
@@ -16,7 +16,7 @@ const (
 
 var _ = Describe("Test config policy controller deployment", func() {
 	It("should create the default config policy controller deployment on the managed cluster", func() {
-		Kubectl("apply", "-f", case2ManagedClusterAddOnCR)
+		Kubectl("apply", "-n", "cluster1", "-f", case2ManagedClusterAddOnCR)
 		deploy := GetWithTimeout(clientDynamic, gvrDeployment, case2ConfigDeploymentName, addonNamespace, true, 30)
 		Expect(deploy).NotTo(BeNil())
 
@@ -50,7 +50,7 @@ var _ = Describe("Test config policy controller deployment", func() {
 		}, 240, 1).Should(Equal(true))
 	})
 	It("should remove the config policy controller deployment when the ManagedClusterAddOn CR is removed", func() {
-		Kubectl("delete", "-f", case2ManagedClusterAddOnCR)
+		Kubectl("delete", "-n", "cluster1", "-f", case2ManagedClusterAddOnCR)
 		deploy := GetWithTimeout(clientDynamic, gvrDeployment, case2ConfigDeploymentName, addonNamespace, false, 30)
 		Expect(deploy).To(BeNil())
 	})

--- a/test/e2e/case2_config_deployment_test.go
+++ b/test/e2e/case2_config_deployment_test.go
@@ -17,23 +17,32 @@ const (
 var _ = Describe("Test config-policy-controller deployment", func() {
 	It("should create the default config-policy-controller deployment on the managed cluster", func() {
 		for _, cluster := range managedClusterList {
-			By(cluster.clusterType + " " + cluster.clusterName + ": deploying the default config-policy-controller managedclusteraddon")
+			By(cluster.clusterType + " " + cluster.clusterName +
+				": deploying the default config-policy-controller managedclusteraddon")
 			Kubectl("apply", "-n", cluster.clusterName, "-f", case2ManagedClusterAddOnCR)
-			deploy := GetWithTimeout(cluster.clusterClient, gvrDeployment, case2ConfigDeploymentName, addonNamespace, true, 30)
+			deploy := GetWithTimeout(
+				cluster.clusterClient, gvrDeployment, case2ConfigDeploymentName, addonNamespace, true, 30,
+			)
 			Expect(deploy).NotTo(BeNil())
 
-			By(cluster.clusterType + " " + cluster.clusterName + ": checking the number of containers in the deployment")
+			By(cluster.clusterType + " " + cluster.clusterName +
+				": checking the number of containers in the deployment")
 			Eventually(func() int {
-				deploy = GetWithTimeout(cluster.clusterClient, gvrDeployment, case2ConfigDeploymentName, addonNamespace, true, 30)
+				deploy = GetWithTimeout(
+					cluster.clusterClient, gvrDeployment, case2ConfigDeploymentName, addonNamespace, true, 30,
+				)
 				spec := deploy.Object["spec"].(map[string]interface{})["template"].(map[string]interface{})["spec"]
 				containers := spec.(map[string]interface{})["containers"]
 
 				return len(containers.([]interface{}))
 			}, 60, 1).Should(Equal(1))
 
-			By(cluster.clusterType + " " + cluster.clusterName + ": verifying all replicas in config-policy-controller deployment are available")
+			By(cluster.clusterType + " " + cluster.clusterName +
+				": verifying all replicas in config-policy-controller deployment are available")
 			Eventually(func() bool {
-				deploy = GetWithTimeout(cluster.clusterClient, gvrDeployment, case2ConfigDeploymentName, addonNamespace, true, 30)
+				deploy = GetWithTimeout(
+					cluster.clusterClient, gvrDeployment, case2ConfigDeploymentName, addonNamespace, true, 30,
+				)
 				status := deploy.Object["status"]
 				replicas := status.(map[string]interface{})["replicas"]
 				availableReplicas := status.(map[string]interface{})["availableReplicas"]
@@ -41,7 +50,8 @@ var _ = Describe("Test config-policy-controller deployment", func() {
 				return (availableReplicas != nil) && replicas.(int64) == availableReplicas.(int64)
 			}, 240, 1).Should(Equal(true))
 
-			By(cluster.clusterType + " " + cluster.clusterName + ": verifying a running config-policy-controller pod")
+			By(cluster.clusterType + " " + cluster.clusterName +
+				": verifying a running config-policy-controller pod")
 			Eventually(func() bool {
 				opts := metav1.ListOptions{
 					LabelSelector: case2ConfigPodSelector,
@@ -52,7 +62,8 @@ var _ = Describe("Test config-policy-controller deployment", func() {
 				return phase.(string) == "Running"
 			}, 60, 1).Should(Equal(true))
 
-			By(cluster.clusterType + " " + cluster.clusterName + ": showing the config-policy-controller managedclusteraddon as available")
+			By(cluster.clusterType + " " + cluster.clusterName +
+				": showing the config-policy-controller managedclusteraddon as available")
 			Eventually(func() bool {
 				addon := GetWithTimeout(
 					clientDynamic, gvrManagedClusterAddOn, case2ConfigDeploymentName, cluster.clusterName, true, 30,
@@ -61,9 +72,12 @@ var _ = Describe("Test config-policy-controller deployment", func() {
 				return getAddonStatus(addon)
 			}, 240, 1).Should(Equal(true))
 
-			By(cluster.clusterType + " " + cluster.clusterName + ": removing the config-policy-controller deployment when the ManagedClusterAddOn CR is removed")
+			By(cluster.clusterType + " " + cluster.clusterName +
+				": removing the config-policy-controller deployment when the ManagedClusterAddOn CR is removed")
 			Kubectl("delete", "-n", cluster.clusterName, "-f", case2ManagedClusterAddOnCR)
-			deploy = GetWithTimeout(cluster.clusterClient, gvrDeployment, case2ConfigDeploymentName, addonNamespace, false, 30)
+			deploy = GetWithTimeout(
+				cluster.clusterClient, gvrDeployment, case2ConfigDeploymentName, addonNamespace, false, 30,
+			)
 			Expect(deploy).To(BeNil())
 		}
 	})

--- a/test/e2e/case2_config_deployment_test.go
+++ b/test/e2e/case2_config_deployment_test.go
@@ -14,44 +14,57 @@ const (
 	case2ConfigPodSelector     string = "app=config-policy-controller"
 )
 
-var _ = Describe("Test config policy controller deployment", func() {
-	It("should create the default config policy controller deployment on the managed cluster", func() {
-		Kubectl("apply", "-n", "cluster1", "-f", case2ManagedClusterAddOnCR)
-		deploy := GetWithTimeout(clientDynamic, gvrDeployment, case2ConfigDeploymentName, addonNamespace, true, 30)
-		Expect(deploy).NotTo(BeNil())
+var _ = Describe("Test config-policy-controller deployment", func() {
+	It("should create the default config-policy-controller deployment on the managed cluster", func() {
+		for _, cluster := range managedClusterList {
+			By(cluster.clusterType + " " + cluster.clusterName + ": deploying the default config-policy-controller managedclusteraddon")
+			Kubectl("apply", "-n", cluster.clusterName, "-f", case2ManagedClusterAddOnCR)
+			deploy := GetWithTimeout(cluster.clusterClient, gvrDeployment, case2ConfigDeploymentName, addonNamespace, true, 30)
+			Expect(deploy).NotTo(BeNil())
 
-		By("checking the number of containers in the deployment")
-		Eventually(func() int {
-			deploy := GetWithTimeout(clientDynamic, gvrDeployment, case2ConfigDeploymentName, addonNamespace, true, 30)
-			spec := deploy.Object["spec"].(map[string]interface{})["template"].(map[string]interface{})["spec"]
-			containers := spec.(map[string]interface{})["containers"]
+			By(cluster.clusterType + " " + cluster.clusterName + ": checking the number of containers in the deployment")
+			Eventually(func() int {
+				deploy = GetWithTimeout(cluster.clusterClient, gvrDeployment, case2ConfigDeploymentName, addonNamespace, true, 30)
+				spec := deploy.Object["spec"].(map[string]interface{})["template"].(map[string]interface{})["spec"]
+				containers := spec.(map[string]interface{})["containers"]
 
-			return len(containers.([]interface{}))
-		}, 60, 1).Should(Equal(1))
-	})
-	It("should have a running config policy controller pod", func() {
-		Eventually(func() bool {
-			opts := metav1.ListOptions{
-				LabelSelector: case2ConfigPodSelector,
-			}
-			pods := ListWithTimeoutByNamespace(clientDynamic, gvrPod, opts, addonNamespace, 1, true, 30)
-			phase := pods.Items[0].Object["status"].(map[string]interface{})["phase"]
+				return len(containers.([]interface{}))
+			}, 60, 1).Should(Equal(1))
 
-			return phase.(string) == "Running"
-		}, 60, 1).Should(Equal(true))
-	})
-	It("should show the config-policy-controller managedclusteraddon as available", func() {
-		Eventually(func() bool {
-			addon := GetWithTimeout(
-				clientDynamic, gvrManagedClusterAddOn, case2ConfigDeploymentName, "cluster1", true, 30,
-			)
+			By(cluster.clusterType + " " + cluster.clusterName + ": verifying all replicas in config-policy-controller deployment are available")
+			Eventually(func() bool {
+				deploy = GetWithTimeout(cluster.clusterClient, gvrDeployment, case2ConfigDeploymentName, addonNamespace, true, 30)
+				status := deploy.Object["status"]
+				replicas := status.(map[string]interface{})["replicas"]
+				availableReplicas := status.(map[string]interface{})["availableReplicas"]
 
-			return getAddonStatus(addon)
-		}, 240, 1).Should(Equal(true))
-	})
-	It("should remove the config policy controller deployment when the ManagedClusterAddOn CR is removed", func() {
-		Kubectl("delete", "-n", "cluster1", "-f", case2ManagedClusterAddOnCR)
-		deploy := GetWithTimeout(clientDynamic, gvrDeployment, case2ConfigDeploymentName, addonNamespace, false, 30)
-		Expect(deploy).To(BeNil())
+				return (availableReplicas != nil) && replicas.(int64) == availableReplicas.(int64)
+			}, 240, 1).Should(Equal(true))
+
+			By(cluster.clusterType + " " + cluster.clusterName + ": verifying a running config-policy-controller pod")
+			Eventually(func() bool {
+				opts := metav1.ListOptions{
+					LabelSelector: case2ConfigPodSelector,
+				}
+				pods := ListWithTimeoutByNamespace(cluster.clusterClient, gvrPod, opts, addonNamespace, 1, true, 30)
+				phase := pods.Items[0].Object["status"].(map[string]interface{})["phase"]
+
+				return phase.(string) == "Running"
+			}, 60, 1).Should(Equal(true))
+
+			By(cluster.clusterType + " " + cluster.clusterName + ": showing the config-policy-controller managedclusteraddon as available")
+			Eventually(func() bool {
+				addon := GetWithTimeout(
+					clientDynamic, gvrManagedClusterAddOn, case2ConfigDeploymentName, cluster.clusterName, true, 30,
+				)
+
+				return getAddonStatus(addon)
+			}, 240, 1).Should(Equal(true))
+
+			By(cluster.clusterType + " " + cluster.clusterName + ": removing the config-policy-controller deployment when the ManagedClusterAddOn CR is removed")
+			Kubectl("delete", "-n", cluster.clusterName, "-f", case2ManagedClusterAddOnCR)
+			deploy = GetWithTimeout(cluster.clusterClient, gvrDeployment, case2ConfigDeploymentName, addonNamespace, false, 30)
+			Expect(deploy).To(BeNil())
+		}
 	})
 })

--- a/test/e2e/case3_iam_deployment_test.go
+++ b/test/e2e/case3_iam_deployment_test.go
@@ -14,7 +14,7 @@ const (
 
 var _ = Describe("Test iam policy controller deployment", func() {
 	It("should create the iam-policy-controller deployment on the managed cluster", func() {
-		Kubectl("apply", "-f", case3ManagedClusterAddOnCR)
+		Kubectl("apply", "-n", "cluster1", "-f", case3ManagedClusterAddOnCR)
 		deploy := GetWithTimeout(clientDynamic, gvrDeployment, case3DeploymentName, addonNamespace, true, 30)
 		Expect(deploy).NotTo(BeNil())
 	})
@@ -36,7 +36,7 @@ var _ = Describe("Test iam policy controller deployment", func() {
 		}, 240, 1).Should(Equal(true))
 	})
 	It("should delete the iam-policy-controller deployment when the ManagedClusterAddOn CR is removed", func() {
-		Kubectl("delete", "-f", case3ManagedClusterAddOnCR)
+		Kubectl("delete", "-n", "cluster1", "-f", case3ManagedClusterAddOnCR)
 		deploy := GetWithTimeout(clientDynamic, gvrDeployment, case3DeploymentName, addonNamespace, false, 30)
 		Expect(deploy).To(BeNil())
 	})

--- a/test/e2e/case3_iam_deployment_test.go
+++ b/test/e2e/case3_iam_deployment_test.go
@@ -17,23 +17,32 @@ const (
 var _ = Describe("Test iam-policy-controller deployment", func() {
 	It("should create the iam-policy-controller deployment on the managed cluster", func() {
 		for _, cluster := range managedClusterList {
-			By(cluster.clusterType + " " + cluster.clusterName + ": deploying the default iam-policy-controller managedclusteraddon")
+			By(cluster.clusterType + " " + cluster.clusterName +
+				": deploying the default iam-policy-controller managedclusteraddon")
 			Kubectl("apply", "-n", cluster.clusterName, "-f", case3ManagedClusterAddOnCR)
-			deploy := GetWithTimeout(cluster.clusterClient, gvrDeployment, case3DeploymentName, addonNamespace, true, 30)
+			deploy := GetWithTimeout(
+				cluster.clusterClient, gvrDeployment, case3DeploymentName, addonNamespace, true, 30,
+			)
 			Expect(deploy).NotTo(BeNil())
 
-			By(cluster.clusterType + " " + cluster.clusterName + ": checking the number of containers in the deployment")
+			By(cluster.clusterType + " " + cluster.clusterName +
+				": checking the number of containers in the deployment")
 			Eventually(func() int {
-				deploy = GetWithTimeout(cluster.clusterClient, gvrDeployment, case3DeploymentName, addonNamespace, true, 30)
+				deploy = GetWithTimeout(
+					cluster.clusterClient, gvrDeployment, case3DeploymentName, addonNamespace, true, 30,
+				)
 				spec := deploy.Object["spec"].(map[string]interface{})["template"].(map[string]interface{})["spec"]
 				containers := spec.(map[string]interface{})["containers"]
 
 				return len(containers.([]interface{}))
 			}, 60, 1).Should(Equal(1))
 
-			By(cluster.clusterType + " " + cluster.clusterName + ": verifying all replicas in iam-policy-controller deployment are available")
+			By(cluster.clusterType + " " + cluster.clusterName +
+				": verifying all replicas in iam-policy-controller deployment are available")
 			Eventually(func() bool {
-				deploy = GetWithTimeout(cluster.clusterClient, gvrDeployment, case3DeploymentName, addonNamespace, true, 30)
+				deploy = GetWithTimeout(
+					cluster.clusterClient, gvrDeployment, case3DeploymentName, addonNamespace, true, 30,
+				)
 				status := deploy.Object["status"]
 				replicas := status.(map[string]interface{})["replicas"]
 				availableReplicas := status.(map[string]interface{})["availableReplicas"]
@@ -41,7 +50,8 @@ var _ = Describe("Test iam-policy-controller deployment", func() {
 				return (availableReplicas != nil) && replicas.(int64) == availableReplicas.(int64)
 			}, 240, 1).Should(Equal(true))
 
-			By(cluster.clusterType + " " + cluster.clusterName + ": verifying a running iam-policy-controller pod")
+			By(cluster.clusterType + " " + cluster.clusterName +
+				": verifying a running iam-policy-controller pod")
 			Eventually(func() bool {
 				opts := metav1.ListOptions{
 					LabelSelector: case3PodSelector,
@@ -52,16 +62,22 @@ var _ = Describe("Test iam-policy-controller deployment", func() {
 				return phase.(string) == "Running"
 			}, 60, 1).Should(Equal(true))
 
-			By(cluster.clusterType + " " + cluster.clusterName + ": showing the iam-policy-controller managedclusteraddon as available")
+			By(cluster.clusterType + " " + cluster.clusterName +
+				": showing the iam-policy-controller managedclusteraddon as available")
 			Eventually(func() bool {
-				addon := GetWithTimeout(clientDynamic, gvrManagedClusterAddOn, case3DeploymentName, cluster.clusterName, true, 30)
+				addon := GetWithTimeout(
+					clientDynamic, gvrManagedClusterAddOn, case3DeploymentName, cluster.clusterName, true, 30,
+				)
 
 				return getAddonStatus(addon)
 			}, 240, 1).Should(Equal(true))
 
-			By(cluster.clusterType + " " + cluster.clusterName + ": removing the iam-policy-controller deployment when the ManagedClusterAddOn CR is removed")
+			By(cluster.clusterType + " " + cluster.clusterName +
+				": removing the iam-policy-controller deployment when the ManagedClusterAddOn CR is removed")
 			Kubectl("delete", "-n", cluster.clusterName, "-f", case3ManagedClusterAddOnCR)
-			deploy = GetWithTimeout(cluster.clusterClient, gvrDeployment, case3DeploymentName, addonNamespace, false, 30)
+			deploy = GetWithTimeout(
+				cluster.clusterClient, gvrDeployment, case3DeploymentName, addonNamespace, false, 30,
+			)
 			Expect(deploy).To(BeNil())
 		}
 	})

--- a/test/e2e/case3_iam_deployment_test.go
+++ b/test/e2e/case3_iam_deployment_test.go
@@ -5,39 +5,64 @@ package e2e
 import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 const (
 	case3ManagedClusterAddOnCR string = "../resources/iam_policy_addon_cr.yaml"
 	case3DeploymentName        string = "iam-policy-controller"
+	case3PodSelector           string = "app=iam-policy-controller"
 )
 
-var _ = Describe("Test iam policy controller deployment", func() {
+var _ = Describe("Test iam-policy-controller deployment", func() {
 	It("should create the iam-policy-controller deployment on the managed cluster", func() {
-		Kubectl("apply", "-n", "cluster1", "-f", case3ManagedClusterAddOnCR)
-		deploy := GetWithTimeout(clientDynamic, gvrDeployment, case3DeploymentName, addonNamespace, true, 30)
-		Expect(deploy).NotTo(BeNil())
-	})
-	It("should have all replicas in iam-policy-controller deployment available", func() {
-		Eventually(func() bool {
-			deploy := GetWithTimeout(clientDynamic, gvrDeployment, case3DeploymentName, addonNamespace, true, 30)
-			status := deploy.Object["status"]
-			replicas := status.(map[string]interface{})["replicas"]
-			availableReplicas := status.(map[string]interface{})["availableReplicas"]
+		for _, cluster := range managedClusterList {
+			By(cluster.clusterType + " " + cluster.clusterName + ": deploying the default iam-policy-controller managedclusteraddon")
+			Kubectl("apply", "-n", cluster.clusterName, "-f", case3ManagedClusterAddOnCR)
+			deploy := GetWithTimeout(cluster.clusterClient, gvrDeployment, case3DeploymentName, addonNamespace, true, 30)
+			Expect(deploy).NotTo(BeNil())
 
-			return (availableReplicas != nil) && replicas.(int64) == availableReplicas.(int64)
-		}, 240, 1).Should(Equal(true))
-	})
-	It("should show the iam-policy-controller managedclusteraddon as available", func() {
-		Eventually(func() bool {
-			addon := GetWithTimeout(clientDynamic, gvrManagedClusterAddOn, case3DeploymentName, "cluster1", true, 30)
+			By(cluster.clusterType + " " + cluster.clusterName + ": checking the number of containers in the deployment")
+			Eventually(func() int {
+				deploy = GetWithTimeout(cluster.clusterClient, gvrDeployment, case3DeploymentName, addonNamespace, true, 30)
+				spec := deploy.Object["spec"].(map[string]interface{})["template"].(map[string]interface{})["spec"]
+				containers := spec.(map[string]interface{})["containers"]
 
-			return getAddonStatus(addon)
-		}, 240, 1).Should(Equal(true))
-	})
-	It("should delete the iam-policy-controller deployment when the ManagedClusterAddOn CR is removed", func() {
-		Kubectl("delete", "-n", "cluster1", "-f", case3ManagedClusterAddOnCR)
-		deploy := GetWithTimeout(clientDynamic, gvrDeployment, case3DeploymentName, addonNamespace, false, 30)
-		Expect(deploy).To(BeNil())
+				return len(containers.([]interface{}))
+			}, 60, 1).Should(Equal(1))
+
+			By(cluster.clusterType + " " + cluster.clusterName + ": verifying all replicas in iam-policy-controller deployment are available")
+			Eventually(func() bool {
+				deploy = GetWithTimeout(cluster.clusterClient, gvrDeployment, case3DeploymentName, addonNamespace, true, 30)
+				status := deploy.Object["status"]
+				replicas := status.(map[string]interface{})["replicas"]
+				availableReplicas := status.(map[string]interface{})["availableReplicas"]
+
+				return (availableReplicas != nil) && replicas.(int64) == availableReplicas.(int64)
+			}, 240, 1).Should(Equal(true))
+
+			By(cluster.clusterType + " " + cluster.clusterName + ": verifying a running iam-policy-controller pod")
+			Eventually(func() bool {
+				opts := metav1.ListOptions{
+					LabelSelector: case3PodSelector,
+				}
+				pods := ListWithTimeoutByNamespace(cluster.clusterClient, gvrPod, opts, addonNamespace, 1, true, 30)
+				phase := pods.Items[0].Object["status"].(map[string]interface{})["phase"]
+
+				return phase.(string) == "Running"
+			}, 60, 1).Should(Equal(true))
+
+			By(cluster.clusterType + " " + cluster.clusterName + ": showing the iam-policy-controller managedclusteraddon as available")
+			Eventually(func() bool {
+				addon := GetWithTimeout(clientDynamic, gvrManagedClusterAddOn, case3DeploymentName, cluster.clusterName, true, 30)
+
+				return getAddonStatus(addon)
+			}, 240, 1).Should(Equal(true))
+
+			By(cluster.clusterType + " " + cluster.clusterName + ": removing the iam-policy-controller deployment when the ManagedClusterAddOn CR is removed")
+			Kubectl("delete", "-n", cluster.clusterName, "-f", case3ManagedClusterAddOnCR)
+			deploy = GetWithTimeout(cluster.clusterClient, gvrDeployment, case3DeploymentName, addonNamespace, false, 30)
+			Expect(deploy).To(BeNil())
+		}
 	})
 })

--- a/test/e2e/case4_cert_deployment_test.go
+++ b/test/e2e/case4_cert_deployment_test.go
@@ -14,7 +14,7 @@ const (
 
 var _ = Describe("Test cert policy controller deployment", func() {
 	It("should create the cert-policy-controller deployment on the managed cluster", func() {
-		Kubectl("apply", "-f", case4ManagedClusterAddOnCR)
+		Kubectl("apply", "-n", "cluster1", "-f", case4ManagedClusterAddOnCR)
 		deploy := GetWithTimeout(clientDynamic, gvrDeployment, case4DeploymentName, addonNamespace, true, 30)
 		Expect(deploy).NotTo(BeNil())
 	})
@@ -36,7 +36,7 @@ var _ = Describe("Test cert policy controller deployment", func() {
 		}, 240, 1).Should(Equal(true))
 	})
 	It("should delete the cert-policy-controller deployment when the ManagedClusterAddOn CR is removed", func() {
-		Kubectl("delete", "-f", case4ManagedClusterAddOnCR)
+		Kubectl("delete", "-n", "cluster1", "-f", case4ManagedClusterAddOnCR)
 		deploy := GetWithTimeout(clientDynamic, gvrDeployment, case4DeploymentName, addonNamespace, false, 30)
 		Expect(deploy).To(BeNil())
 	})

--- a/test/e2e/case4_cert_deployment_test.go
+++ b/test/e2e/case4_cert_deployment_test.go
@@ -5,39 +5,64 @@ package e2e
 import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 const (
 	case4ManagedClusterAddOnCR string = "../resources/cert_policy_addon_cr.yaml"
 	case4DeploymentName        string = "cert-policy-controller"
+	case4PodSelector           string = "app=cert-policy-controller"
 )
 
-var _ = Describe("Test cert policy controller deployment", func() {
+var _ = Describe("Test cert-policy-controller deployment", func() {
 	It("should create the cert-policy-controller deployment on the managed cluster", func() {
-		Kubectl("apply", "-n", "cluster1", "-f", case4ManagedClusterAddOnCR)
-		deploy := GetWithTimeout(clientDynamic, gvrDeployment, case4DeploymentName, addonNamespace, true, 30)
-		Expect(deploy).NotTo(BeNil())
-	})
-	It("should have all replicas in cert-policy-controller deployment available", func() {
-		Eventually(func() bool {
-			deploy := GetWithTimeout(clientDynamic, gvrDeployment, case4DeploymentName, addonNamespace, true, 30)
-			status := deploy.Object["status"]
-			replicas := status.(map[string]interface{})["replicas"]
-			availableReplicas := status.(map[string]interface{})["availableReplicas"]
+		for _, cluster := range managedClusterList {
+			By(cluster.clusterType + " " + cluster.clusterName + ": deploying the default cert-policy-controller managedclusteraddon")
+			Kubectl("apply", "-n", cluster.clusterName, "-f", case4ManagedClusterAddOnCR)
+			deploy := GetWithTimeout(cluster.clusterClient, gvrDeployment, case4DeploymentName, addonNamespace, true, 30)
+			Expect(deploy).NotTo(BeNil())
 
-			return (availableReplicas != nil) && replicas.(int64) == availableReplicas.(int64)
-		}, 240, 1).Should(Equal(true))
-	})
-	It("should show the cert-policy-controller managedclusteraddon as available", func() {
-		Eventually(func() bool {
-			addon := GetWithTimeout(clientDynamic, gvrManagedClusterAddOn, case4DeploymentName, "cluster1", true, 30)
+			By(cluster.clusterType + " " + cluster.clusterName + ": checking the number of containers in the deployment")
+			Eventually(func() int {
+				deploy = GetWithTimeout(cluster.clusterClient, gvrDeployment, case4DeploymentName, addonNamespace, true, 30)
+				spec := deploy.Object["spec"].(map[string]interface{})["template"].(map[string]interface{})["spec"]
+				containers := spec.(map[string]interface{})["containers"]
 
-			return getAddonStatus(addon)
-		}, 240, 1).Should(Equal(true))
-	})
-	It("should delete the cert-policy-controller deployment when the ManagedClusterAddOn CR is removed", func() {
-		Kubectl("delete", "-n", "cluster1", "-f", case4ManagedClusterAddOnCR)
-		deploy := GetWithTimeout(clientDynamic, gvrDeployment, case4DeploymentName, addonNamespace, false, 30)
-		Expect(deploy).To(BeNil())
+				return len(containers.([]interface{}))
+			}, 60, 1).Should(Equal(1))
+
+			By(cluster.clusterType + " " + cluster.clusterName + ": verifying all replicas in cert-policy-controller deployment are available")
+			Eventually(func() bool {
+				deploy = GetWithTimeout(cluster.clusterClient, gvrDeployment, case4DeploymentName, addonNamespace, true, 30)
+				status := deploy.Object["status"]
+				replicas := status.(map[string]interface{})["replicas"]
+				availableReplicas := status.(map[string]interface{})["availableReplicas"]
+
+				return (availableReplicas != nil) && replicas.(int64) == availableReplicas.(int64)
+			}, 240, 1).Should(Equal(true))
+
+			By(cluster.clusterType + " " + cluster.clusterName + ": verifying a running cert-policy-controller pod")
+			Eventually(func() bool {
+				opts := metav1.ListOptions{
+					LabelSelector: case4PodSelector,
+				}
+				pods := ListWithTimeoutByNamespace(cluster.clusterClient, gvrPod, opts, addonNamespace, 1, true, 30)
+				phase := pods.Items[0].Object["status"].(map[string]interface{})["phase"]
+
+				return phase.(string) == "Running"
+			}, 60, 1).Should(Equal(true))
+
+			By(cluster.clusterType + " " + cluster.clusterName + ": showing the cert-policy-controller managedclusteraddon as available")
+			Eventually(func() bool {
+				addon := GetWithTimeout(clientDynamic, gvrManagedClusterAddOn, case4DeploymentName, cluster.clusterName, true, 30)
+
+				return getAddonStatus(addon)
+			}, 240, 1).Should(Equal(true))
+
+			By(cluster.clusterType + " " + cluster.clusterName + ": removing the cert-policy-controller deployment when the ManagedClusterAddOn CR is removed")
+			Kubectl("delete", "-n", cluster.clusterName, "-f", case4ManagedClusterAddOnCR)
+			deploy = GetWithTimeout(cluster.clusterClient, gvrDeployment, case4DeploymentName, addonNamespace, false, 30)
+			Expect(deploy).To(BeNil())
+		}
 	})
 })

--- a/test/e2e/case4_cert_deployment_test.go
+++ b/test/e2e/case4_cert_deployment_test.go
@@ -17,23 +17,32 @@ const (
 var _ = Describe("Test cert-policy-controller deployment", func() {
 	It("should create the cert-policy-controller deployment on the managed cluster", func() {
 		for _, cluster := range managedClusterList {
-			By(cluster.clusterType + " " + cluster.clusterName + ": deploying the default cert-policy-controller managedclusteraddon")
+			By(cluster.clusterType + " " + cluster.clusterName +
+				": deploying the default cert-policy-controller managedclusteraddon")
 			Kubectl("apply", "-n", cluster.clusterName, "-f", case4ManagedClusterAddOnCR)
-			deploy := GetWithTimeout(cluster.clusterClient, gvrDeployment, case4DeploymentName, addonNamespace, true, 30)
+			deploy := GetWithTimeout(
+				cluster.clusterClient, gvrDeployment, case4DeploymentName, addonNamespace, true, 30,
+			)
 			Expect(deploy).NotTo(BeNil())
 
-			By(cluster.clusterType + " " + cluster.clusterName + ": checking the number of containers in the deployment")
+			By(cluster.clusterType + " " + cluster.clusterName +
+				": checking the number of containers in the deployment")
 			Eventually(func() int {
-				deploy = GetWithTimeout(cluster.clusterClient, gvrDeployment, case4DeploymentName, addonNamespace, true, 30)
+				deploy = GetWithTimeout(
+					cluster.clusterClient, gvrDeployment, case4DeploymentName, addonNamespace, true, 30,
+				)
 				spec := deploy.Object["spec"].(map[string]interface{})["template"].(map[string]interface{})["spec"]
 				containers := spec.(map[string]interface{})["containers"]
 
 				return len(containers.([]interface{}))
 			}, 60, 1).Should(Equal(1))
 
-			By(cluster.clusterType + " " + cluster.clusterName + ": verifying all replicas in cert-policy-controller deployment are available")
+			By(cluster.clusterType + " " + cluster.clusterName +
+				": verifying all replicas in cert-policy-controller deployment are available")
 			Eventually(func() bool {
-				deploy = GetWithTimeout(cluster.clusterClient, gvrDeployment, case4DeploymentName, addonNamespace, true, 30)
+				deploy = GetWithTimeout(
+					cluster.clusterClient, gvrDeployment, case4DeploymentName, addonNamespace, true, 30,
+				)
 				status := deploy.Object["status"]
 				replicas := status.(map[string]interface{})["replicas"]
 				availableReplicas := status.(map[string]interface{})["availableReplicas"]
@@ -41,7 +50,8 @@ var _ = Describe("Test cert-policy-controller deployment", func() {
 				return (availableReplicas != nil) && replicas.(int64) == availableReplicas.(int64)
 			}, 240, 1).Should(Equal(true))
 
-			By(cluster.clusterType + " " + cluster.clusterName + ": verifying a running cert-policy-controller pod")
+			By(cluster.clusterType + " " + cluster.clusterName +
+				": verifying a running cert-policy-controller pod")
 			Eventually(func() bool {
 				opts := metav1.ListOptions{
 					LabelSelector: case4PodSelector,
@@ -52,16 +62,22 @@ var _ = Describe("Test cert-policy-controller deployment", func() {
 				return phase.(string) == "Running"
 			}, 60, 1).Should(Equal(true))
 
-			By(cluster.clusterType + " " + cluster.clusterName + ": showing the cert-policy-controller managedclusteraddon as available")
+			By(cluster.clusterType + " " + cluster.clusterName +
+				": showing the cert-policy-controller managedclusteraddon as available")
 			Eventually(func() bool {
-				addon := GetWithTimeout(clientDynamic, gvrManagedClusterAddOn, case4DeploymentName, cluster.clusterName, true, 30)
+				addon := GetWithTimeout(
+					clientDynamic, gvrManagedClusterAddOn, case4DeploymentName, cluster.clusterName, true, 30,
+				)
 
 				return getAddonStatus(addon)
 			}, 240, 1).Should(Equal(true))
 
-			By(cluster.clusterType + " " + cluster.clusterName + ": removing the cert-policy-controller deployment when the ManagedClusterAddOn CR is removed")
+			By(cluster.clusterType + " " + cluster.clusterName +
+				": removing the cert-policy-controller deployment when the ManagedClusterAddOn CR is removed")
 			Kubectl("delete", "-n", cluster.clusterName, "-f", case4ManagedClusterAddOnCR)
-			deploy = GetWithTimeout(cluster.clusterClient, gvrDeployment, case4DeploymentName, addonNamespace, false, 30)
+			deploy = GetWithTimeout(
+				cluster.clusterClient, gvrDeployment, case4DeploymentName, addonNamespace, false, 30,
+			)
 			Expect(deploy).To(BeNil())
 		}
 	})

--- a/test/e2e/e2e_suite_test.go
+++ b/test/e2e/e2e_suite_test.go
@@ -65,11 +65,13 @@ func getManagedClusters(client dynamic.Interface) []managedClusterConfig {
 	}
 
 	var clusters []managedClusterConfig
+
 	for i, cluster := range clusterObjs.Items {
 		clusterName, _, err := unstructured.NestedString(cluster.Object, "metadata", "name")
 		if err != nil {
 			panic(err)
 		}
+
 		clusterClient := NewKubeClientDynamic("", fmt.Sprintf("%s%d.kubeconfig", kubeconfigFilename, i+1), "")
 
 		var clusterType string

--- a/test/e2e/e2e_suite_test.go
+++ b/test/e2e/e2e_suite_test.go
@@ -3,6 +3,7 @@
 package e2e
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"os/user"
@@ -11,6 +12,8 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/rest"
@@ -18,15 +21,24 @@ import (
 )
 
 const (
-	addonNamespace string = "open-cluster-management-agent-addon"
+	addonNamespace     string = "open-cluster-management-agent-addon"
+	kubeconfigFilename string = "../../policy-addon-ctrl"
 )
 
 var (
 	gvrDeployment          schema.GroupVersionResource
 	gvrPod                 schema.GroupVersionResource
 	gvrManagedClusterAddOn schema.GroupVersionResource
+	gvrManagedCluster      schema.GroupVersionResource
+	managedClusterList     []managedClusterConfig
 	clientDynamic          dynamic.Interface
 )
+
+type managedClusterConfig struct {
+	clusterName   string
+	clusterClient dynamic.Interface
+	clusterType   string
+}
 
 func TestE2e(t *testing.T) {
 	RegisterFailHandler(Fail)
@@ -39,8 +51,44 @@ var _ = BeforeSuite(func() {
 	gvrManagedClusterAddOn = schema.GroupVersionResource{
 		Group: "addon.open-cluster-management.io", Version: "v1alpha1", Resource: "managedclusteraddons",
 	}
-	clientDynamic = NewKubeClientDynamic("", "../../policy-addon-ctrl.kubeconfig", "")
+	gvrManagedCluster = schema.GroupVersionResource{
+		Group: "cluster.open-cluster-management.io", Version: "v1", Resource: "managedclusters",
+	}
+	clientDynamic = NewKubeClientDynamic("", kubeconfigFilename+"1.kubeconfig", "")
+	managedClusterList = getManagedClusters(clientDynamic)
 })
+
+func getManagedClusters(client dynamic.Interface) []managedClusterConfig {
+	clusterObjs, err := client.Resource(gvrManagedCluster).List(context.TODO(), metav1.ListOptions{})
+	if err != nil {
+		panic(err)
+	}
+
+	var clusters []managedClusterConfig
+	for i, cluster := range clusterObjs.Items {
+		clusterName, _, err := unstructured.NestedString(cluster.Object, "metadata", "name")
+		if err != nil {
+			panic(err)
+		}
+		clusterClient := NewKubeClientDynamic("", fmt.Sprintf("%s%d.kubeconfig", kubeconfigFilename, i+1), "")
+
+		var clusterType string
+		if i == 0 {
+			clusterType = "hub"
+		} else {
+			clusterType = "managed"
+		}
+
+		newCluster := managedClusterConfig{
+			clusterName,
+			clusterClient,
+			clusterType,
+		}
+		clusters = append(clusters, newCluster)
+	}
+
+	return clusters
+}
 
 func NewKubeClientDynamic(url, kubeconfig, context string) dynamic.Interface {
 	config, err := LoadConfig(url, kubeconfig, context)

--- a/test/e2e/utils.go
+++ b/test/e2e/utils.go
@@ -18,6 +18,8 @@ import (
 
 // Kubectl executes kubectl commands
 func Kubectl(args ...string) {
+	// Inject the kubeconfig to ensure we're pointing to the hub
+	args = append(args, "--kubeconfig="+kubeconfigFilename+"1.kubeconfig")
 	cmd := exec.Command("kubectl", args...)
 
 	output, err := cmd.CombinedOutput()

--- a/test/resources/cert_policy_addon_cr.yaml
+++ b/test/resources/cert_policy_addon_cr.yaml
@@ -2,6 +2,5 @@ apiVersion: addon.open-cluster-management.io/v1alpha1
 kind: ManagedClusterAddOn
 metadata:
   name: cert-policy-controller
-  namespace: cluster1
 spec:
   installNamespace: open-cluster-management-agent-addon

--- a/test/resources/config_policy_addon_cr.yaml
+++ b/test/resources/config_policy_addon_cr.yaml
@@ -2,6 +2,5 @@ apiVersion: addon.open-cluster-management.io/v1alpha1
 kind: ManagedClusterAddOn
 metadata:
   name: config-policy-controller
-  namespace: cluster1
 spec:
   installNamespace: open-cluster-management-agent-addon

--- a/test/resources/framework_addon_cr.yaml
+++ b/test/resources/framework_addon_cr.yaml
@@ -2,6 +2,5 @@ apiVersion: addon.open-cluster-management.io/v1alpha1
 kind: ManagedClusterAddOn
 metadata:
   name: governance-policy-framework
-  namespace: cluster1
 spec:
   installNamespace: open-cluster-management-agent-addon

--- a/test/resources/iam_policy_addon_cr.yaml
+++ b/test/resources/iam_policy_addon_cr.yaml
@@ -2,6 +2,5 @@ apiVersion: addon.open-cluster-management.io/v1alpha1
 kind: ManagedClusterAddOn
 metadata:
   name: iam-policy-controller
-  namespace: cluster1
 spec:
   installNamespace: open-cluster-management-agent-addon


### PR DESCRIPTION
Apparently Ginkgo doesn't know the value of anything in `BeforeSuite` until the `Describe` and `It` have already been evaluated, so wrapping an `It` statement in a loop didn't work. I had to nest the `for` loops to iterate over the clusters inside of the `It` functions, which meant I reflowed pretty much all of the tests. However I was trying to test one cluster at a time but then realized that I could have had a loop inside of each `It` statement, the benefit being that it would probably be slightly faster (and perhaps more realistic?) but less isolated.

Addresses:
- https://github.com/stolostron/backlog/issues/20016