### PR TITLE
Add pause annotation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ ENVTEST_K8S_VERSION = 1.23
 
 PWD := $(shell pwd)
 BASE_DIR := $(shell basename $(PWD))
-export PATH=$(shell echo $$PATH):$(PWD)/bin
+export PATH=$(PWD)/bin:$(shell echo $$PATH)
 # Keep an existing GOPATH, make a private one if it is undefined
 GOPATH_DEFAULT := $(PWD)/.go
 export GOPATH ?= $(GOPATH_DEFAULT)

--- a/pkg/addon/common.go
+++ b/pkg/addon/common.go
@@ -3,7 +3,6 @@ package addon
 import (
 	"context"
 	"embed"
-	"encoding/json"
 	"fmt"
 	"os"
 
@@ -53,7 +52,8 @@ func NewRegistrationOption(
 	filesystem embed.FS,
 ) *agent.RegistrationOption {
 	applyManifestFromFile := func(file, clusterName string,
-		kubeclient *kubernetes.Clientset, recorder events.Recorder) error {
+		kubeclient *kubernetes.Clientset, recorder events.Recorder,
+	) error {
 		groups := agent.DefaultGroups(clusterName, addonName)
 		config := struct {
 			ClusterName string
@@ -121,49 +121,10 @@ func GetAndAddAgent(
 		return fmt.Errorf("failed getting the %v agent addon: %w", addonName, err)
 	}
 
-	if os.Getenv("SIMULATION_MODE") == "on" {
-		agentAddon = &SimulationAgent{a: agentAddon}
-	}
-
 	err = mgr.AddAgent(agentAddon)
 	if err != nil {
 		return fmt.Errorf("failed adding the %v agent addon to the manager: %w", addonName, err)
 	}
 
 	return nil
-}
-
-type SimulationAgent struct {
-	a agent.AgentAddon
-}
-
-func (sim *SimulationAgent) Manifests(cluster *clusterv1.ManagedCluster,
-	addon *addonapiv1alpha1.ManagedClusterAddOn) ([]runtime.Object, error) {
-	realObjs, err := sim.a.Manifests(cluster, addon)
-
-	log.Info("Simulation Agent Manifests:")
-
-	for _, obj := range realObjs {
-		b, err := json.Marshal(obj)
-		if err != nil {
-			log.Error(err, "Failed to marshal object")
-		}
-
-		log.Info("Mashalling was successful", string(b))
-	}
-
-	return []runtime.Object{}, err
-}
-
-func (sim *SimulationAgent) GetAgentAddonOptions() agent.AgentAddonOptions {
-	opts := sim.a.GetAgentAddonOptions()
-
-	opts.Registration.PermissionConfig = func(cluster *clusterv1.ManagedCluster,
-		addon *addonapiv1alpha1.ManagedClusterAddOn) error {
-		log.Info("Simulation Agent permission config skipped")
-
-		return nil
-	}
-
-	return opts
 }

--- a/test/e2e/e2e_suite_test.go
+++ b/test/e2e/e2e_suite_test.go
@@ -30,6 +30,7 @@ var (
 	gvrPod                 schema.GroupVersionResource
 	gvrManagedClusterAddOn schema.GroupVersionResource
 	gvrManagedCluster      schema.GroupVersionResource
+	gvrManifestWork        schema.GroupVersionResource
 	managedClusterList     []managedClusterConfig
 	clientDynamic          dynamic.Interface
 )
@@ -53,6 +54,9 @@ var _ = BeforeSuite(func() {
 	}
 	gvrManagedCluster = schema.GroupVersionResource{
 		Group: "cluster.open-cluster-management.io", Version: "v1", Resource: "managedclusters",
+	}
+	gvrManifestWork = schema.GroupVersionResource{
+		Group: "work.open-cluster-management.io", Version: "v1", Resource: "manifestworks",
 	}
 	clientDynamic = NewKubeClientDynamic("", kubeconfigFilename+"1.kubeconfig", "")
 	managedClusterList = getManagedClusters(clientDynamic)

--- a/test/resources/manifestwork_add_patch.json
+++ b/test/resources/manifestwork_add_patch.json
@@ -1,0 +1,17 @@
+[
+  {
+    "op": "add",
+    "path": "/spec/workload/manifests/-",
+    "value": {
+      "apiVersion": "v1",
+      "kind": "ConfigMap",
+      "metadata": {
+        "name": "mw-patch-test",
+        "namespace": "open-cluster-management-agent-addon"
+      },
+      "data": {
+        "foo": "bar"
+      }
+    }
+  }
+]


### PR DESCRIPTION
Setting the `policy-addon-pause=true` annotation will effectively pause the reconciliation of the ManifestWork, allowing on-the-fly edits.

Also removed some now-unused code