### PR TITLE
Configure log level and encoding for addons

### DIFF
--- a/pkg/addon/certpolicy/agent_addon.go
+++ b/pkg/addon/certpolicy/agent_addon.go
@@ -47,6 +47,17 @@ func getValues(cluster *clusterv1.ManagedCluster,
 				"NO_PROXY":    "",
 			},
 		},
+		UserArgs: policyaddon.UserArgs{
+			LogEncoder:  "console",
+			LogLevel:    0,
+			PkgLogLevel: -1,
+		},
+	}
+
+	if val, ok := addon.GetAnnotations()[policyaddon.PolicyLogLevelAnnotation]; ok {
+		logLevel := policyaddon.GetLogLevel(addonName, val)
+		userValues.UserArgs.LogLevel = logLevel
+		userValues.UserArgs.PkgLogLevel = logLevel - 2
 	}
 
 	return addonfactory.JsonStructToValues(userValues)

--- a/pkg/addon/certpolicy/manifests/managedclusterchart/templates/deployment.yaml
+++ b/pkg/addon/certpolicy/manifests/managedclusterchart/templates/deployment.yaml
@@ -42,6 +42,9 @@ spec:
         {{- if semverCompare "< 1.14.0" .Capabilities.KubeVersion.Version }}
         - --legacy-leader-elect=true
         {{- end }}
+        - --log-encoder={{ .Values.args.logEncoder }}
+        - --log-level={{ .Values.args.logLevel }}
+        - --v={{ .Values.args.pkgLogLevel }}
         env:
         - name: WATCH_NAMESPACE
           value: "{{ .Values.clusterName }}"

--- a/pkg/addon/certpolicy/manifests/managedclusterchart/values.yaml
+++ b/pkg/addon/certpolicy/manifests/managedclusterchart/values.yaml
@@ -8,6 +8,9 @@ replicas: 1
 args:
   frequency: 30
   defaultDuration: null
+  logLevel: 0
+  pkgLogLevel: -1
+  logEncoder: console
 
 resources:
   requests:

--- a/pkg/addon/common.go
+++ b/pkg/addon/common.go
@@ -5,6 +5,7 @@ import (
 	"embed"
 	"fmt"
 	"os"
+	"strconv"
 
 	"github.com/openshift/library-go/pkg/assets"
 	"github.com/openshift/library-go/pkg/controller/controllercmd"
@@ -23,7 +24,10 @@ import (
 
 var log = ctrl.Log.WithName("common")
 
-const PolicyAddonPauseAnnotation = "policy-addon-pause"
+const (
+	PolicyAddonPauseAnnotation = "policy-addon-pause"
+	PolicyLogLevelAnnotation   = "log-level"
+)
 
 type GlobalValues struct {
 	ImagePullPolicy string            `json:"imagePullPolicy,"`
@@ -33,8 +37,15 @@ type GlobalValues struct {
 	ProxyConfig     map[string]string `json:"proxyConfig,"`
 }
 
+type UserArgs struct {
+	LogEncoder  string `json:"logEncoder,"`
+	LogLevel    int8   `json:"logLevel,"`
+	PkgLogLevel int8   `json:"pkgLogLevel,"`
+}
+
 type UserValues struct {
 	GlobalValues GlobalValues `json:"global,"`
+	UserArgs     UserArgs     `json:"args,"`
 }
 
 var genericScheme = runtime.NewScheme()
@@ -147,4 +158,20 @@ func (pa *PolicyAgentAddon) Manifests(cluster *clusterv1.ManagedCluster,
 	}
 
 	return pa.AgentAddon.Manifests(cluster, addon)
+}
+
+// getLogLevel verifies the user-provided log level against Zap, returning 0 if the check fails.
+func GetLogLevel(component string, level string) int8 {
+	logDefault := int8(0)
+	logLevel, err := strconv.ParseInt(level, 10, 8)
+	if err != nil || logLevel < 0 {
+		log.Error(err, fmt.Sprintf(
+			"Failed to verify '%s' annotation value '%s' for component %s (falling back to default value %d)",
+			PolicyLogLevelAnnotation, level, component, logDefault),
+		)
+		return logDefault
+	}
+
+	// This is safe because we specified the int8 in ParseInt
+	return int8(logLevel)
 }

--- a/pkg/addon/common.go
+++ b/pkg/addon/common.go
@@ -163,12 +163,14 @@ func (pa *PolicyAgentAddon) Manifests(cluster *clusterv1.ManagedCluster,
 // getLogLevel verifies the user-provided log level against Zap, returning 0 if the check fails.
 func GetLogLevel(component string, level string) int8 {
 	logDefault := int8(0)
+
 	logLevel, err := strconv.ParseInt(level, 10, 8)
 	if err != nil || logLevel < 0 {
 		log.Error(err, fmt.Sprintf(
 			"Failed to verify '%s' annotation value '%s' for component %s (falling back to default value %d)",
 			PolicyLogLevelAnnotation, level, component, logDefault),
 		)
+
 		return logDefault
 	}
 

--- a/pkg/addon/configpolicy/agent_addon.go
+++ b/pkg/addon/configpolicy/agent_addon.go
@@ -47,6 +47,17 @@ func getValues(cluster *clusterv1.ManagedCluster,
 				"NO_PROXY":    "",
 			},
 		},
+		UserArgs: policyaddon.UserArgs{
+			LogEncoder:  "console",
+			LogLevel:    0,
+			PkgLogLevel: -1,
+		},
+	}
+
+	if val, ok := addon.GetAnnotations()[policyaddon.PolicyLogLevelAnnotation]; ok {
+		logLevel := policyaddon.GetLogLevel(addonName, val)
+		userValues.UserArgs.LogLevel = logLevel
+		userValues.UserArgs.PkgLogLevel = logLevel - 2
 	}
 
 	return addonfactory.JsonStructToValues(userValues)

--- a/pkg/addon/configpolicy/manifests/managedclusterchart/templates/deployment.yaml
+++ b/pkg/addon/configpolicy/manifests/managedclusterchart/templates/deployment.yaml
@@ -37,6 +37,9 @@ spec:
           {{- if semverCompare "< 1.14.0" .Capabilities.KubeVersion.Version }}
           - --legacy-leader-elect=true
           {{- end }}
+          - --log-encoder={{ .Values.args.logEncoder }}
+          - --log-level={{ .Values.args.logLevel }}
+          - --v={{ .Values.args.pkgLogLevel }}
         env:
           - name: WATCH_NAMESPACE
             value: "{{ .Values.clusterName }}"

--- a/pkg/addon/configpolicy/manifests/managedclusterchart/values.yaml
+++ b/pkg/addon/configpolicy/manifests/managedclusterchart/values.yaml
@@ -5,7 +5,10 @@ nameOverride: null
 
 org: open-cluster-management
 replicas: 1
-
+args:
+  logLevel: 0
+  pkgLogLevel: -1
+  logEncoder: console
 hubKubeConfigSecret: config-policy-controller-hub-kubeconfig
 
 resources:

--- a/pkg/addon/iampolicy/agent_addon.go
+++ b/pkg/addon/iampolicy/agent_addon.go
@@ -47,6 +47,17 @@ func getValues(cluster *clusterv1.ManagedCluster,
 				"NO_PROXY":    "",
 			},
 		},
+		UserArgs: policyaddon.UserArgs{
+			LogEncoder:  "console",
+			LogLevel:    0,
+			PkgLogLevel: -1,
+		},
+	}
+
+	if val, ok := addon.GetAnnotations()[policyaddon.PolicyLogLevelAnnotation]; ok {
+		logLevel := policyaddon.GetLogLevel(addonName, val)
+		userValues.UserArgs.LogLevel = logLevel
+		userValues.UserArgs.PkgLogLevel = logLevel - 2
 	}
 
 	return addonfactory.JsonStructToValues(userValues)

--- a/pkg/addon/iampolicy/manifests/managedclusterchart/templates/deployment.yaml
+++ b/pkg/addon/iampolicy/manifests/managedclusterchart/templates/deployment.yaml
@@ -39,6 +39,9 @@ spec:
         {{- if semverCompare "< 1.14.0" .Capabilities.KubeVersion.Version }}
         - --legacy-leader-elect=true
         {{- end }}
+        - --log-encoder={{ .Values.args.logEncoder }}
+        - --log-level={{ .Values.args.logLevel }}
+        - --v={{ .Values.args.pkgLogLevel }}
         env:
         - name: WATCH_NAMESPACE
           value: "{{ .Values.clusterName }}"

--- a/pkg/addon/iampolicy/manifests/managedclusterchart/values.yaml
+++ b/pkg/addon/iampolicy/manifests/managedclusterchart/values.yaml
@@ -7,7 +7,9 @@ org: open-cluster-management
 replicas: 1
 args:
   frequency: 30
-
+  logLevel: 0
+  pkgLogLevel: -1
+  logEncoding: console
 securityContext:
   privileged: false
   allowPrivilegeEscalation: false

--- a/pkg/addon/policyframework/agent_addon.go
+++ b/pkg/addon/policyframework/agent_addon.go
@@ -35,6 +35,7 @@ var agentPermissionFiles = []string{
 type userValues struct {
 	OnMulticlusterHub bool                     `json:"onMulticlusterHub"`
 	GlobalValues      policyaddon.GlobalValues `json:"global"`
+	UserArgs          policyaddon.UserArgs     `json:"args"`
 }
 
 func getValues(cluster *clusterv1.ManagedCluster,
@@ -56,6 +57,11 @@ func getValues(cluster *clusterv1.ManagedCluster,
 				"NO_PROXY":    "",
 			},
 		},
+		UserArgs: policyaddon.UserArgs{
+			LogEncoder:  "console",
+			LogLevel:    0,
+			PkgLogLevel: -1,
+		},
 	}
 	// special case for local-cluster
 	if cluster.Name == "local-cluster" {
@@ -69,6 +75,12 @@ func getValues(cluster *clusterv1.ManagedCluster,
 			// the special case can still be overridden by this annotation
 			userValues.OnMulticlusterHub = false
 		}
+	}
+
+	if val, ok := addon.GetAnnotations()[policyaddon.PolicyLogLevelAnnotation]; ok {
+		logLevel := policyaddon.GetLogLevel(addonName, val)
+		userValues.UserArgs.LogLevel = logLevel
+		userValues.UserArgs.PkgLogLevel = logLevel - 2
 	}
 
 	return addonfactory.JsonStructToValues(userValues)

--- a/pkg/addon/policyframework/manifests/managedclusterchart/templates/deployment.yaml
+++ b/pkg/addon/policyframework/manifests/managedclusterchart/templates/deployment.yaml
@@ -38,6 +38,9 @@ spec:
           {{- if semverCompare "< 1.14.0" .Capabilities.KubeVersion.Version }}
           - --legacy-leader-elect=true
           {{- end }}
+          - --log-encoder={{ .Values.args.logEncoder }}
+          - --log-level={{ .Values.args.logLevel }}
+          - --v={{ .Values.args.pkgLogLevel }}
         env:
           - name: WATCH_NAMESPACE
             value: "{{ .Values.clusterName }}"
@@ -90,6 +93,9 @@ spec:
           {{- if semverCompare "< 1.14.0" .Capabilities.KubeVersion.Version }}
           - --legacy-leader-elect=true
           {{- end }}
+          - --log-encoder={{ .Values.args.logEncoder }}
+          - --log-level={{ .Values.args.logLevel }}
+          - --v={{ .Values.args.pkgLogLevel }}
         env:
           - name: WATCH_NAMESPACE
             value: "{{ .Values.clusterName }}"
@@ -138,6 +144,10 @@ spec:
         image: "{{ .Values.global.imageOverrides.governance_policy_template_sync }}"
         imagePullPolicy: "{{ .Values.global.imagePullPolicy }}"
         command: ["governance-policy-template-sync"]
+        args:
+          - --log-encoder={{ .Values.args.logEncoder }}
+          - --log-level={{ .Values.args.logLevel }}
+          - --v={{ .Values.args.pkgLogLevel }}
         env:
           - name: WATCH_NAMESPACE
             value: "{{ .Values.clusterName }}"

--- a/pkg/addon/policyframework/manifests/managedclusterchart/values.yaml
+++ b/pkg/addon/policyframework/manifests/managedclusterchart/values.yaml
@@ -7,6 +7,10 @@ onMulticlusterHub: false
 
 org: open-cluster-management
 replicas: 1
+args:
+  logLevel: 0
+  pkgLogLevel: -1
+  logEncoder: console
 hubKubeConfigSecret: governance-policy-framework-hub-kubeconfig
 
 resources:

--- a/test/e2e/case1_framework_deployment_test.go
+++ b/test/e2e/case1_framework_deployment_test.go
@@ -50,7 +50,7 @@ var _ = Describe("Test framework deployment", func() {
 				return (availableReplicas != nil) && replicas.(int64) == availableReplicas.(int64)
 			}, 240, 1).Should(Equal(true))
 
-			By(logPrefix + ": verifying a framework pod is running")
+			By(logPrefix + "verifying a framework pod is running")
 			Eventually(func() bool {
 				opts := metav1.ListOptions{
 					LabelSelector: case1PodSelector,
@@ -101,7 +101,7 @@ var _ = Describe("Test framework deployment", func() {
 			By(logPrefix + "annotating the managedclusteraddon with the " + loggingLevelAnnotation + " annotation")
 			Kubectl("annotate", "-n", cluster.clusterName, "-f", case1ManagedClusterAddOnCR, loggingLevelAnnotation)
 
-			By(logPrefix + ": verifying a new framework pod is deployed")
+			By(logPrefix + "verifying a new framework pod is deployed")
 			opts := metav1.ListOptions{
 				LabelSelector: case1PodSelector,
 			}
@@ -172,7 +172,7 @@ var _ = Describe("Test framework deployment", func() {
 				return (availableReplicas != nil) && replicas.(int64) == availableReplicas.(int64)
 			}, 240, 1).Should(Equal(true))
 
-			By(logPrefix + ": verifying a framework pod is running")
+			By(logPrefix + "verifying a framework pod is running")
 			Eventually(func() bool {
 				opts := metav1.ListOptions{
 					LabelSelector: case1PodSelector,
@@ -195,7 +195,7 @@ var _ = Describe("Test framework deployment", func() {
 			By(logPrefix + "annotating the managedclusteraddon with the " + loggingLevelAnnotation + " annotation")
 			Kubectl("annotate", "-n", cluster.clusterName, "-f", case1ManagedClusterAddOnCR, loggingLevelAnnotation)
 
-			By(logPrefix + ": verifying a new framework pod is deployed")
+			By(logPrefix + "verifying a new framework pod is deployed")
 			opts := metav1.ListOptions{
 				LabelSelector: case1PodSelector,
 			}
@@ -218,7 +218,7 @@ var _ = Describe("Test framework deployment", func() {
 				}
 			}
 
-			By(logPrefix + ": deleting the managedclusteraddon")
+			By(logPrefix + "deleting the managedclusteraddon")
 			Kubectl("delete", "-n", cluster.clusterName, "-f", case1ManagedClusterAddOnCR)
 			deploy = GetWithTimeout(
 				cluster.clusterClient, gvrDeployment, case1DeploymentName, addonNamespace, false, 30,
@@ -263,7 +263,7 @@ var _ = Describe("Test framework deployment", func() {
 				return (availableReplicas != nil) && replicas.(int64) == availableReplicas.(int64)
 			}, 240, 1).Should(Equal(true))
 
-			By(logPrefix + ": verifying a framework pod is running")
+			By(logPrefix + "verifying a framework pod is running")
 			Eventually(func() bool {
 				opts := metav1.ListOptions{
 					LabelSelector: case1PodSelector,
@@ -286,7 +286,7 @@ var _ = Describe("Test framework deployment", func() {
 			By(logPrefix + "annotating the managedclusteraddon with the " + loggingLevelAnnotation + " annotation")
 			Kubectl("annotate", "-n", cluster.clusterName, "-f", case1ManagedClusterAddOnCR, loggingLevelAnnotation)
 
-			By(logPrefix + ": verifying a new framework pod is deployed")
+			By(logPrefix + "verifying a new framework pod is deployed")
 			opts := metav1.ListOptions{
 				LabelSelector: case1PodSelector,
 			}
@@ -307,7 +307,7 @@ var _ = Describe("Test framework deployment", func() {
 				}
 			}
 
-			By(logPrefix + ": deleting the managedclusteraddon")
+			By(logPrefix + "deleting the managedclusteraddon")
 			Kubectl("delete", "-n", cluster.clusterName, "-f", case1ManagedClusterAddOnCR)
 			deploy = GetWithTimeout(
 				cluster.clusterClient, gvrDeployment, case1DeploymentName, addonNamespace, false, 30,
@@ -336,11 +336,11 @@ var _ = Describe("Test framework deployment", func() {
 				return defaultLength
 			}, 60, 5).ShouldNot(Equal(0))
 
-			By(logPrefix + ": patching the ManifestWork to add an item")
+			By(logPrefix + "patching the ManifestWork to add an item")
 			Kubectl("patch", "-n", cluster.clusterName, "manifestwork", case1MWName, "--type=json",
 				"--patch-file="+case1MWPatch)
 
-			By(logPrefix + ": verifying the edit is reverted")
+			By(logPrefix + "verifying the edit is reverted")
 			Eventually(func() int {
 				mw := GetWithTimeout(clientDynamic, gvrManifestWork, case1MWName, cluster.clusterName, true, 15)
 				manifests, _, _ := unstructured.NestedSlice(mw.Object, "spec", "workload", "manifests")
@@ -348,7 +348,7 @@ var _ = Describe("Test framework deployment", func() {
 				return len(manifests)
 			}, 60, 5).Should(Equal(defaultLength))
 
-			By(logPrefix + ": deleting the managedclusteraddon")
+			By(logPrefix + "deleting the managedclusteraddon")
 			Kubectl("delete", "-n", cluster.clusterName, "-f", case1ManagedClusterAddOnCR)
 			deploy = GetWithTimeout(
 				cluster.clusterClient, gvrDeployment, case1DeploymentName, addonNamespace, false, 30,
@@ -379,11 +379,11 @@ var _ = Describe("Test framework deployment", func() {
 				return defaultLength
 			}, 60, 5).ShouldNot(Equal(0))
 
-			By(logPrefix + ": patching the ManifestWork to add an item")
+			By(logPrefix + "patching the ManifestWork to add an item")
 			Kubectl("patch", "-n", cluster.clusterName, "manifestwork", case1MWName, "--type=json",
 				"--patch-file="+case1MWPatch)
 
-			By(logPrefix + ": verifying the edit is not reverted")
+			By(logPrefix + "verifying the edit is not reverted")
 			Consistently(func() int {
 				mw := GetWithTimeout(clientDynamic, gvrManifestWork, case1MWName, cluster.clusterName, true, 15)
 				manifests, _, _ := unstructured.NestedSlice(mw.Object, "spec", "workload", "manifests")
@@ -391,7 +391,7 @@ var _ = Describe("Test framework deployment", func() {
 				return len(manifests)
 			}, 30, 5).Should(Equal(defaultLength + 1))
 
-			By(logPrefix + ": deleting the managedclusteraddon")
+			By(logPrefix + "deleting the managedclusteraddon")
 			Kubectl("delete", "-n", cluster.clusterName, "-f", case1ManagedClusterAddOnCR)
 			deploy = GetWithTimeout(
 				cluster.clusterClient, gvrDeployment, case1DeploymentName, addonNamespace, false, 30,

--- a/test/e2e/case1_framework_deployment_test.go
+++ b/test/e2e/case1_framework_deployment_test.go
@@ -10,11 +10,11 @@ import (
 )
 
 const (
-	case1ManagedClusterAddOnCR   string = "../resources/framework_addon_cr.yaml"
-	case1FrameworkDeploymentName string = "governance-policy-framework"
-	case1FrameworkPodSelector    string = "app=governance-policy-framework"
-	case1MWName                  string = "addon-governance-policy-framework-deploy"
-	case1MWPatch                 string = "../resources/manifestwork_add_patch.json"
+	case1ManagedClusterAddOnCR string = "../resources/framework_addon_cr.yaml"
+	case1DeploymentName        string = "governance-policy-framework"
+	case1PodSelector           string = "app=governance-policy-framework"
+	case1MWName                string = "addon-governance-policy-framework-deploy"
+	case1MWPatch               string = "../resources/manifestwork_add_patch.json"
 )
 
 var _ = Describe("Test framework deployment", func() {
@@ -24,14 +24,14 @@ var _ = Describe("Test framework deployment", func() {
 			By(logPrefix + "deploying the default framework managedclusteraddon")
 			Kubectl("apply", "-n", cluster.clusterName, "-f", case1ManagedClusterAddOnCR)
 			deploy := GetWithTimeout(
-				cluster.clusterClient, gvrDeployment, case1FrameworkDeploymentName, addonNamespace, true, 30,
+				cluster.clusterClient, gvrDeployment, case1DeploymentName, addonNamespace, true, 30,
 			)
 			Expect(deploy).NotTo(BeNil())
 
 			By(logPrefix + "checking the number of containers in the deployment")
 			Eventually(func() int {
 				deploy = GetWithTimeout(cluster.clusterClient, gvrDeployment,
-					case1FrameworkDeploymentName, addonNamespace, true, 30)
+					case1DeploymentName, addonNamespace, true, 30)
 				spec := deploy.Object["spec"].(map[string]interface{})["template"].(map[string]interface{})["spec"]
 				containers := spec.(map[string]interface{})["containers"]
 
@@ -41,7 +41,7 @@ var _ = Describe("Test framework deployment", func() {
 			By(logPrefix + "verifying all replicas in framework deployment are available")
 			Eventually(func() bool {
 				deploy = GetWithTimeout(
-					cluster.clusterClient, gvrDeployment, case1FrameworkDeploymentName, addonNamespace, true, 30,
+					cluster.clusterClient, gvrDeployment, case1DeploymentName, addonNamespace, true, 30,
 				)
 				status := deploy.Object["status"]
 				replicas := status.(map[string]interface{})["replicas"]
@@ -53,7 +53,7 @@ var _ = Describe("Test framework deployment", func() {
 			By(logPrefix + ": verifying a framework pod is running")
 			Eventually(func() bool {
 				opts := metav1.ListOptions{
-					LabelSelector: case1FrameworkPodSelector,
+					LabelSelector: case1PodSelector,
 				}
 				pods := ListWithTimeoutByNamespace(cluster.clusterClient, gvrPod, opts, addonNamespace, 1, true, 30)
 				phase := pods.Items[0].Object["status"].(map[string]interface{})["phase"]
@@ -64,7 +64,7 @@ var _ = Describe("Test framework deployment", func() {
 			By(logPrefix + "showing the framework managedclusteraddon as available")
 			Eventually(func() bool {
 				addon := GetWithTimeout(
-					clientDynamic, gvrManagedClusterAddOn, case1FrameworkDeploymentName, cluster.clusterName, true, 30,
+					clientDynamic, gvrManagedClusterAddOn, case1DeploymentName, cluster.clusterName, true, 30,
 				)
 
 				return getAddonStatus(addon)
@@ -73,7 +73,7 @@ var _ = Describe("Test framework deployment", func() {
 			By(logPrefix + "removing the framework deployment when the ManagedClusterAddOn CR is removed")
 			Kubectl("delete", "-n", cluster.clusterName, "-f", case1ManagedClusterAddOnCR)
 			deploy = GetWithTimeout(
-				cluster.clusterClient, gvrDeployment, case1FrameworkDeploymentName, addonNamespace, false, 30,
+				cluster.clusterClient, gvrDeployment, case1DeploymentName, addonNamespace, false, 30,
 			)
 			Expect(deploy).To(BeNil())
 		}
@@ -85,7 +85,7 @@ var _ = Describe("Test framework deployment", func() {
 			By(logPrefix + "deploying the default framework managedclusteraddon")
 			Kubectl("apply", "-n", cluster.clusterName, "-f", case1ManagedClusterAddOnCR)
 			deploy := GetWithTimeout(
-				cluster.clusterClient, gvrDeployment, case1FrameworkDeploymentName, addonNamespace, true, 30,
+				cluster.clusterClient, gvrDeployment, case1DeploymentName, addonNamespace, true, 30,
 			)
 			Expect(deploy).NotTo(BeNil())
 
@@ -96,7 +96,7 @@ var _ = Describe("Test framework deployment", func() {
 			By(logPrefix + "checking the number of containers in the deployment")
 			Eventually(func() int {
 				deploy = GetWithTimeout(cluster.clusterClient, gvrDeployment,
-					case1FrameworkDeploymentName, addonNamespace, true, 30)
+					case1DeploymentName, addonNamespace, true, 30)
 				spec := deploy.Object["spec"].(map[string]interface{})["template"].(map[string]interface{})["spec"]
 				containers := spec.(map[string]interface{})["containers"]
 
@@ -106,7 +106,7 @@ var _ = Describe("Test framework deployment", func() {
 			By(logPrefix + "verifying all replicas in framework deployment are available")
 			Eventually(func() bool {
 				deploy = GetWithTimeout(
-					cluster.clusterClient, gvrDeployment, case1FrameworkDeploymentName, addonNamespace, true, 30,
+					cluster.clusterClient, gvrDeployment, case1DeploymentName, addonNamespace, true, 30,
 				)
 				status := deploy.Object["status"]
 				replicas := status.(map[string]interface{})["replicas"]
@@ -118,7 +118,7 @@ var _ = Describe("Test framework deployment", func() {
 			By(logPrefix + ": verifying a framework pod is running")
 			Eventually(func() bool {
 				opts := metav1.ListOptions{
-					LabelSelector: case1FrameworkPodSelector,
+					LabelSelector: case1PodSelector,
 				}
 				pods := ListWithTimeoutByNamespace(cluster.clusterClient, gvrPod, opts, addonNamespace, 1, true, 30)
 				phase := pods.Items[0].Object["status"].(map[string]interface{})["phase"]
@@ -129,7 +129,7 @@ var _ = Describe("Test framework deployment", func() {
 			By(logPrefix + "showing the framework managedclusteraddon as available")
 			Eventually(func() bool {
 				addon := GetWithTimeout(
-					clientDynamic, gvrManagedClusterAddOn, case1FrameworkDeploymentName, cluster.clusterName, true, 30,
+					clientDynamic, gvrManagedClusterAddOn, case1DeploymentName, cluster.clusterName, true, 30,
 				)
 
 				return getAddonStatus(addon)
@@ -138,7 +138,7 @@ var _ = Describe("Test framework deployment", func() {
 			By(cluster.clusterType + " " + cluster.clusterName + ": deleting the managedclusteraddon")
 			Kubectl("delete", "-n", cluster.clusterName, "-f", case1ManagedClusterAddOnCR)
 			deploy = GetWithTimeout(
-				cluster.clusterClient, gvrDeployment, case1FrameworkDeploymentName, addonNamespace, false, 30,
+				cluster.clusterClient, gvrDeployment, case1DeploymentName, addonNamespace, false, 30,
 			)
 			Expect(deploy).To(BeNil())
 		}
@@ -150,7 +150,7 @@ var _ = Describe("Test framework deployment", func() {
 			By(logPrefix + "deploying the default framework managedclusteraddon")
 			Kubectl("apply", "-n", cluster.clusterName, "-f", case1ManagedClusterAddOnCR)
 			deploy := GetWithTimeout(
-				cluster.clusterClient, gvrDeployment, case1FrameworkDeploymentName, addonNamespace, true, 30,
+				cluster.clusterClient, gvrDeployment, case1DeploymentName, addonNamespace, true, 30,
 			)
 			Expect(deploy).NotTo(BeNil())
 
@@ -161,7 +161,7 @@ var _ = Describe("Test framework deployment", func() {
 			By(logPrefix + "checking the number of containers in the deployment")
 			Eventually(func() int {
 				deploy = GetWithTimeout(cluster.clusterClient, gvrDeployment,
-					case1FrameworkDeploymentName, addonNamespace, true, 30)
+					case1DeploymentName, addonNamespace, true, 30)
 				spec := deploy.Object["spec"].(map[string]interface{})["template"].(map[string]interface{})["spec"]
 				containers := spec.(map[string]interface{})["containers"]
 
@@ -171,7 +171,7 @@ var _ = Describe("Test framework deployment", func() {
 			By(logPrefix + "verifying all replicas in framework deployment are available")
 			Eventually(func() bool {
 				deploy = GetWithTimeout(
-					cluster.clusterClient, gvrDeployment, case1FrameworkDeploymentName, addonNamespace, true, 30,
+					cluster.clusterClient, gvrDeployment, case1DeploymentName, addonNamespace, true, 30,
 				)
 				status := deploy.Object["status"]
 				replicas := status.(map[string]interface{})["replicas"]
@@ -183,7 +183,7 @@ var _ = Describe("Test framework deployment", func() {
 			By(logPrefix + ": verifying a framework pod is running")
 			Eventually(func() bool {
 				opts := metav1.ListOptions{
-					LabelSelector: case1FrameworkPodSelector,
+					LabelSelector: case1PodSelector,
 				}
 				pods := ListWithTimeoutByNamespace(cluster.clusterClient, gvrPod, opts, addonNamespace, 1, true, 30)
 				phase := pods.Items[0].Object["status"].(map[string]interface{})["phase"]
@@ -194,7 +194,7 @@ var _ = Describe("Test framework deployment", func() {
 			By(logPrefix + "showing the framework managedclusteraddon as available")
 			Eventually(func() bool {
 				addon := GetWithTimeout(
-					clientDynamic, gvrManagedClusterAddOn, case1FrameworkDeploymentName, cluster.clusterName, true, 30,
+					clientDynamic, gvrManagedClusterAddOn, case1DeploymentName, cluster.clusterName, true, 30,
 				)
 
 				return getAddonStatus(addon)
@@ -203,7 +203,7 @@ var _ = Describe("Test framework deployment", func() {
 			By(cluster.clusterType + " " + cluster.clusterName + ": deleting the managedclusteraddon")
 			Kubectl("delete", "-n", cluster.clusterName, "-f", case1ManagedClusterAddOnCR)
 			deploy = GetWithTimeout(
-				cluster.clusterClient, gvrDeployment, case1FrameworkDeploymentName, addonNamespace, false, 30,
+				cluster.clusterClient, gvrDeployment, case1DeploymentName, addonNamespace, false, 30,
 			)
 			Expect(deploy).To(BeNil())
 		}
@@ -215,7 +215,7 @@ var _ = Describe("Test framework deployment", func() {
 			By(logPrefix + "deploying the default framework managedclusteraddon")
 			Kubectl("apply", "-n", cluster.clusterName, "-f", case1ManagedClusterAddOnCR)
 			deploy := GetWithTimeout(
-				cluster.clusterClient, gvrDeployment, case1FrameworkDeploymentName, addonNamespace, true, 30,
+				cluster.clusterClient, gvrDeployment, case1DeploymentName, addonNamespace, true, 30,
 			)
 			Expect(deploy).NotTo(BeNil())
 
@@ -244,7 +244,7 @@ var _ = Describe("Test framework deployment", func() {
 			By(logPrefix + ": deleting the managedclusteraddon")
 			Kubectl("delete", "-n", cluster.clusterName, "-f", case1ManagedClusterAddOnCR)
 			deploy = GetWithTimeout(
-				cluster.clusterClient, gvrDeployment, case1FrameworkDeploymentName, addonNamespace, false, 30,
+				cluster.clusterClient, gvrDeployment, case1DeploymentName, addonNamespace, false, 30,
 			)
 			Expect(deploy).To(BeNil())
 		}
@@ -255,7 +255,7 @@ var _ = Describe("Test framework deployment", func() {
 			By(logPrefix + "deploying the default framework managedclusteraddon")
 			Kubectl("apply", "-n", cluster.clusterName, "-f", case1ManagedClusterAddOnCR)
 			deploy := GetWithTimeout(
-				cluster.clusterClient, gvrDeployment, case1FrameworkDeploymentName, addonNamespace, true, 30,
+				cluster.clusterClient, gvrDeployment, case1DeploymentName, addonNamespace, true, 30,
 			)
 			Expect(deploy).NotTo(BeNil())
 
@@ -287,7 +287,7 @@ var _ = Describe("Test framework deployment", func() {
 			By(logPrefix + ": deleting the managedclusteraddon")
 			Kubectl("delete", "-n", cluster.clusterName, "-f", case1ManagedClusterAddOnCR)
 			deploy = GetWithTimeout(
-				cluster.clusterClient, gvrDeployment, case1FrameworkDeploymentName, addonNamespace, false, 30,
+				cluster.clusterClient, gvrDeployment, case1DeploymentName, addonNamespace, false, 30,
 			)
 			Expect(deploy).To(BeNil())
 		}

--- a/test/e2e/case1_framework_deployment_test.go
+++ b/test/e2e/case1_framework_deployment_test.go
@@ -70,6 +70,32 @@ var _ = Describe("Test framework deployment", func() {
 				return getAddonStatus(addon)
 			}, 240, 1).Should(Equal(true))
 
+			By(logPrefix + "annotating the managedclusteraddon with the " + loggingLevelAnnotation + " annotation")
+			Kubectl("annotate", "-n", cluster.clusterName, "-f", case1ManagedClusterAddOnCR, loggingLevelAnnotation)
+
+			By(cluster.clusterType + " " + cluster.clusterName + ": verifying a new framework pod is deployed")
+			opts := metav1.ListOptions{
+				LabelSelector: case1PodSelector,
+			}
+			_ = ListWithTimeoutByNamespace(cluster.clusterClient, gvrPod, opts, addonNamespace, 2, true, 30)
+
+			By(logPrefix + "verifying the pod has been deployed with a new logging level")
+			pods := ListWithTimeoutByNamespace(cluster.clusterClient, gvrPod, opts, addonNamespace, 1, true, 60)
+
+			containerList, _, err := unstructured.NestedSlice(pods.Items[0].Object, "spec", "containers")
+			if err != nil {
+				panic(err)
+			}
+
+			for _, container := range containerList {
+				if Expect(container).To(HaveKey("args")) {
+					args := container.(map[string]interface{})["args"]
+					Expect(args).To(ContainElement("--log-encoder=console"))
+					Expect(args).To(ContainElement("--log-level=8"))
+					Expect(args).To(ContainElement("--v=6"))
+				}
+			}
+
 			By(logPrefix + "removing the framework deployment when the ManagedClusterAddOn CR is removed")
 			Kubectl("delete", "-n", cluster.clusterName, "-f", case1ManagedClusterAddOnCR)
 			deploy = GetWithTimeout(
@@ -135,6 +161,32 @@ var _ = Describe("Test framework deployment", func() {
 				return getAddonStatus(addon)
 			}, 240, 1).Should(Equal(true))
 
+			By(logPrefix + "annotating the managedclusteraddon with the " + loggingLevelAnnotation + " annotation")
+			Kubectl("annotate", "-n", cluster.clusterName, "-f", case1ManagedClusterAddOnCR, loggingLevelAnnotation)
+
+			By(cluster.clusterType + " " + cluster.clusterName + ": verifying a new framework pod is deployed")
+			opts := metav1.ListOptions{
+				LabelSelector: case1PodSelector,
+			}
+			_ = ListWithTimeoutByNamespace(cluster.clusterClient, gvrPod, opts, addonNamespace, 2, true, 30)
+
+			By(logPrefix + "verifying the pod has been deployed with a new logging level")
+			pods := ListWithTimeoutByNamespace(cluster.clusterClient, gvrPod, opts, addonNamespace, 1, true, 60)
+
+			containerList, _, err := unstructured.NestedSlice(pods.Items[0].Object, "spec", "containers")
+			if err != nil {
+				panic(err)
+			}
+
+			for _, container := range containerList {
+				if Expect(container).To(HaveKey("args")) {
+					args := container.(map[string]interface{})["args"]
+					Expect(args).To(ContainElement("--log-encoder=console"))
+					Expect(args).To(ContainElement("--log-level=8"))
+					Expect(args).To(ContainElement("--v=6"))
+				}
+			}
+
 			By(cluster.clusterType + " " + cluster.clusterName + ": deleting the managedclusteraddon")
 			Kubectl("delete", "-n", cluster.clusterName, "-f", case1ManagedClusterAddOnCR)
 			deploy = GetWithTimeout(
@@ -199,6 +251,30 @@ var _ = Describe("Test framework deployment", func() {
 
 				return getAddonStatus(addon)
 			}, 240, 1).Should(Equal(true))
+
+			By(logPrefix + "annotating the managedclusteraddon with the " + loggingLevelAnnotation + " annotation")
+			Kubectl("annotate", "-n", cluster.clusterName, "-f", case1ManagedClusterAddOnCR, loggingLevelAnnotation)
+
+			By(cluster.clusterType + " " + cluster.clusterName + ": verifying a new framework pod is deployed")
+			opts := metav1.ListOptions{
+				LabelSelector: case1PodSelector,
+			}
+			_ = ListWithTimeoutByNamespace(cluster.clusterClient, gvrPod, opts, addonNamespace, 2, true, 30)
+
+			By(logPrefix + "verifying the pod has been deployed with a new logging level")
+			pods := ListWithTimeoutByNamespace(cluster.clusterClient, gvrPod, opts, addonNamespace, 1, true, 60)
+			containerList, _, err := unstructured.NestedSlice(pods.Items[0].Object, "spec", "containers")
+			if err != nil {
+				panic(err)
+			}
+			for _, container := range containerList {
+				if Expect(container).To(HaveKey("args")) {
+					args := container.(map[string]interface{})["args"]
+					Expect(args).To(ContainElement("--log-encoder=console"))
+					Expect(args).To(ContainElement("--log-level=8"))
+					Expect(args).To(ContainElement("--v=6"))
+				}
+			}
 
 			By(cluster.clusterType + " " + cluster.clusterName + ": deleting the managedclusteraddon")
 			Kubectl("delete", "-n", cluster.clusterName, "-f", case1ManagedClusterAddOnCR)

--- a/test/e2e/case1_framework_deployment_test.go
+++ b/test/e2e/case1_framework_deployment_test.go
@@ -20,16 +20,15 @@ const (
 var _ = Describe("Test framework deployment", func() {
 	It("should create the default framework deployment", func() {
 		for _, cluster := range managedClusterList {
-			By(cluster.clusterType + " " + cluster.clusterName +
-				": deploying the default framework managedclusteraddon")
+			logPrefix := cluster.clusterType + " " + cluster.clusterName + ": "
+			By(logPrefix + "deploying the default framework managedclusteraddon")
 			Kubectl("apply", "-n", cluster.clusterName, "-f", case1ManagedClusterAddOnCR)
 			deploy := GetWithTimeout(
 				cluster.clusterClient, gvrDeployment, case1FrameworkDeploymentName, addonNamespace, true, 30,
 			)
 			Expect(deploy).NotTo(BeNil())
 
-			By(cluster.clusterType + " " + cluster.clusterName +
-				": checking the number of containers in the deployment")
+			By(logPrefix + "checking the number of containers in the deployment")
 			Eventually(func() int {
 				deploy = GetWithTimeout(cluster.clusterClient, gvrDeployment,
 					case1FrameworkDeploymentName, addonNamespace, true, 30)
@@ -39,8 +38,7 @@ var _ = Describe("Test framework deployment", func() {
 				return len(containers.([]interface{}))
 			}, 60, 1).Should(Equal(3))
 
-			By(cluster.clusterType + " " + cluster.clusterName +
-				": verifying all replicas in framework deployment are available")
+			By(logPrefix + "verifying all replicas in framework deployment are available")
 			Eventually(func() bool {
 				deploy = GetWithTimeout(
 					cluster.clusterClient, gvrDeployment, case1FrameworkDeploymentName, addonNamespace, true, 30,
@@ -52,7 +50,7 @@ var _ = Describe("Test framework deployment", func() {
 				return (availableReplicas != nil) && replicas.(int64) == availableReplicas.(int64)
 			}, 240, 1).Should(Equal(true))
 
-			By(cluster.clusterType + " " + cluster.clusterName + ": verifying a framework pod is running")
+			By(logPrefix + ": verifying a framework pod is running")
 			Eventually(func() bool {
 				opts := metav1.ListOptions{
 					LabelSelector: case1FrameworkPodSelector,
@@ -63,8 +61,7 @@ var _ = Describe("Test framework deployment", func() {
 				return phase.(string) == "Running"
 			}, 60, 1).Should(Equal(true))
 
-			By(cluster.clusterType + " " + cluster.clusterName +
-				": showing the framework managedclusteraddon as available")
+			By(logPrefix + "showing the framework managedclusteraddon as available")
 			Eventually(func() bool {
 				addon := GetWithTimeout(
 					clientDynamic, gvrManagedClusterAddOn, case1FrameworkDeploymentName, cluster.clusterName, true, 30,
@@ -73,8 +70,7 @@ var _ = Describe("Test framework deployment", func() {
 				return getAddonStatus(addon)
 			}, 240, 1).Should(Equal(true))
 
-			By(cluster.clusterType + " " + cluster.clusterName +
-				": removing the framework deployment when the ManagedClusterAddOn CR is removed")
+			By(logPrefix + "removing the framework deployment when the ManagedClusterAddOn CR is removed")
 			Kubectl("delete", "-n", cluster.clusterName, "-f", case1ManagedClusterAddOnCR)
 			deploy = GetWithTimeout(
 				cluster.clusterClient, gvrDeployment, case1FrameworkDeploymentName, addonNamespace, false, 30,
@@ -85,21 +81,19 @@ var _ = Describe("Test framework deployment", func() {
 
 	It("should deploy with 2 containers if onManagedClusterHub is set in helm values annotation", func() {
 		for _, cluster := range managedClusterList {
-			By(cluster.clusterType + " " + cluster.clusterName +
-				": deploying the default framework managedclusteraddon")
+			logPrefix := cluster.clusterType + " " + cluster.clusterName + ": "
+			By(logPrefix + "deploying the default framework managedclusteraddon")
 			Kubectl("apply", "-n", cluster.clusterName, "-f", case1ManagedClusterAddOnCR)
 			deploy := GetWithTimeout(
 				cluster.clusterClient, gvrDeployment, case1FrameworkDeploymentName, addonNamespace, true, 30,
 			)
 			Expect(deploy).NotTo(BeNil())
 
-			By(cluster.clusterType + " " + cluster.clusterName +
-				": annotating the framework managedclusteraddon with helm values")
+			By(logPrefix + "annotating the framework managedclusteraddon with helm values")
 			Kubectl("annotate", "-n", cluster.clusterName, "-f", case1ManagedClusterAddOnCR,
 				"addon.open-cluster-management.io/values={\"onMulticlusterHub\":true}")
 
-			By(cluster.clusterType + " " + cluster.clusterName +
-				": checking the number of containers in the deployment")
+			By(logPrefix + "checking the number of containers in the deployment")
 			Eventually(func() int {
 				deploy = GetWithTimeout(cluster.clusterClient, gvrDeployment,
 					case1FrameworkDeploymentName, addonNamespace, true, 30)
@@ -109,8 +103,7 @@ var _ = Describe("Test framework deployment", func() {
 				return len(containers.([]interface{}))
 			}, 60, 1).Should(Equal(2))
 
-			By(cluster.clusterType + " " + cluster.clusterName +
-				": verifying all replicas in framework deployment are available")
+			By(logPrefix + "verifying all replicas in framework deployment are available")
 			Eventually(func() bool {
 				deploy = GetWithTimeout(
 					cluster.clusterClient, gvrDeployment, case1FrameworkDeploymentName, addonNamespace, true, 30,
@@ -122,7 +115,7 @@ var _ = Describe("Test framework deployment", func() {
 				return (availableReplicas != nil) && replicas.(int64) == availableReplicas.(int64)
 			}, 240, 1).Should(Equal(true))
 
-			By(cluster.clusterType + " " + cluster.clusterName + ": verifying a framework pod is running")
+			By(logPrefix + ": verifying a framework pod is running")
 			Eventually(func() bool {
 				opts := metav1.ListOptions{
 					LabelSelector: case1FrameworkPodSelector,
@@ -133,8 +126,7 @@ var _ = Describe("Test framework deployment", func() {
 				return phase.(string) == "Running"
 			}, 60, 1).Should(Equal(true))
 
-			By(cluster.clusterType + " " + cluster.clusterName +
-				": showing the framework managedclusteraddon as available")
+			By(logPrefix + "showing the framework managedclusteraddon as available")
 			Eventually(func() bool {
 				addon := GetWithTimeout(
 					clientDynamic, gvrManagedClusterAddOn, case1FrameworkDeploymentName, cluster.clusterName, true, 30,
@@ -154,21 +146,19 @@ var _ = Describe("Test framework deployment", func() {
 
 	It("should deploy with 2 containers if onManagedClusterHub is set in the custom annotation", func() {
 		for _, cluster := range managedClusterList {
-			By(cluster.clusterType + " " + cluster.clusterName +
-				": deploying the default framework managedclusteraddon")
+			logPrefix := cluster.clusterType + " " + cluster.clusterName + ": "
+			By(logPrefix + "deploying the default framework managedclusteraddon")
 			Kubectl("apply", "-n", cluster.clusterName, "-f", case1ManagedClusterAddOnCR)
 			deploy := GetWithTimeout(
 				cluster.clusterClient, gvrDeployment, case1FrameworkDeploymentName, addonNamespace, true, 30,
 			)
 			Expect(deploy).NotTo(BeNil())
 
-			By(cluster.clusterType + " " + cluster.clusterName +
-				": annotating the framework managedclusteraddon with custom annotation")
+			By(logPrefix + "annotating the framework managedclusteraddon with custom annotation")
 			Kubectl("annotate", "-n", cluster.clusterName, "-f", case1ManagedClusterAddOnCR,
 				"addon.open-cluster-management.io/on-multicluster-hub=true")
 
-			By(cluster.clusterType + " " + cluster.clusterName +
-				": checking the number of containers in the deployment")
+			By(logPrefix + "checking the number of containers in the deployment")
 			Eventually(func() int {
 				deploy = GetWithTimeout(cluster.clusterClient, gvrDeployment,
 					case1FrameworkDeploymentName, addonNamespace, true, 30)
@@ -178,8 +168,7 @@ var _ = Describe("Test framework deployment", func() {
 				return len(containers.([]interface{}))
 			}, 60, 1).Should(Equal(2))
 
-			By(cluster.clusterType + " " + cluster.clusterName +
-				": verifying all replicas in framework deployment are available")
+			By(logPrefix + "verifying all replicas in framework deployment are available")
 			Eventually(func() bool {
 				deploy = GetWithTimeout(
 					cluster.clusterClient, gvrDeployment, case1FrameworkDeploymentName, addonNamespace, true, 30,
@@ -191,7 +180,7 @@ var _ = Describe("Test framework deployment", func() {
 				return (availableReplicas != nil) && replicas.(int64) == availableReplicas.(int64)
 			}, 240, 1).Should(Equal(true))
 
-			By(cluster.clusterType + " " + cluster.clusterName + ": verifying a framework pod is running")
+			By(logPrefix + ": verifying a framework pod is running")
 			Eventually(func() bool {
 				opts := metav1.ListOptions{
 					LabelSelector: case1FrameworkPodSelector,
@@ -202,8 +191,7 @@ var _ = Describe("Test framework deployment", func() {
 				return phase.(string) == "Running"
 			}, 60, 1).Should(Equal(true))
 
-			By(cluster.clusterType + " " + cluster.clusterName +
-				": showing the framework managedclusteraddon as available")
+			By(logPrefix + "showing the framework managedclusteraddon as available")
 			Eventually(func() bool {
 				addon := GetWithTimeout(
 					clientDynamic, gvrManagedClusterAddOn, case1FrameworkDeploymentName, cluster.clusterName, true, 30,
@@ -223,16 +211,15 @@ var _ = Describe("Test framework deployment", func() {
 
 	It("should revert edits to the ManifestWork by default", func() {
 		for _, cluster := range managedClusterList {
-			By(cluster.clusterType + " " + cluster.clusterName +
-				": deploying the default framework managedclusteraddon")
+			logPrefix := cluster.clusterType + " " + cluster.clusterName + ": "
+			By(logPrefix + "deploying the default framework managedclusteraddon")
 			Kubectl("apply", "-n", cluster.clusterName, "-f", case1ManagedClusterAddOnCR)
 			deploy := GetWithTimeout(
 				cluster.clusterClient, gvrDeployment, case1FrameworkDeploymentName, addonNamespace, true, 30,
 			)
 			Expect(deploy).NotTo(BeNil())
 
-			By(cluster.clusterType + " " + cluster.clusterName +
-				": getting the default number of items in the ManifestWork")
+			By(logPrefix + "getting the default number of items in the ManifestWork")
 			defaultLength := 0
 			Eventually(func() int {
 				mw := GetWithTimeout(clientDynamic, gvrManifestWork, case1MWName, cluster.clusterName, true, 15)
@@ -242,11 +229,11 @@ var _ = Describe("Test framework deployment", func() {
 				return defaultLength
 			}, 60, 5).ShouldNot(Equal(0))
 
-			By(cluster.clusterType + " " + cluster.clusterName + ": patching the ManifestWork to add an item")
+			By(logPrefix + ": patching the ManifestWork to add an item")
 			Kubectl("patch", "-n", cluster.clusterName, "manifestwork", case1MWName, "--type=json",
 				"--patch-file="+case1MWPatch)
 
-			By(cluster.clusterType + " " + cluster.clusterName + ": verifying the edit is reverted")
+			By(logPrefix + ": verifying the edit is reverted")
 			Eventually(func() int {
 				mw := GetWithTimeout(clientDynamic, gvrManifestWork, case1MWName, cluster.clusterName, true, 15)
 				manifests, _, _ := unstructured.NestedSlice(mw.Object, "spec", "workload", "manifests")
@@ -254,7 +241,7 @@ var _ = Describe("Test framework deployment", func() {
 				return len(manifests)
 			}, 60, 5).Should(Equal(defaultLength))
 
-			By(cluster.clusterType + " " + cluster.clusterName + ": deleting the managedclusteraddon")
+			By(logPrefix + ": deleting the managedclusteraddon")
 			Kubectl("delete", "-n", cluster.clusterName, "-f", case1ManagedClusterAddOnCR)
 			deploy = GetWithTimeout(
 				cluster.clusterClient, gvrDeployment, case1FrameworkDeploymentName, addonNamespace, false, 30,
@@ -264,20 +251,18 @@ var _ = Describe("Test framework deployment", func() {
 	})
 	It("should preserve edits to the ManifestWork if paused by annotation", func() {
 		for _, cluster := range managedClusterList {
-			By(cluster.clusterType + " " + cluster.clusterName +
-				": deploying the default framework managedclusteraddon")
+			logPrefix := cluster.clusterType + " " + cluster.clusterName + ": "
+			By(logPrefix + "deploying the default framework managedclusteraddon")
 			Kubectl("apply", "-n", cluster.clusterName, "-f", case1ManagedClusterAddOnCR)
 			deploy := GetWithTimeout(
 				cluster.clusterClient, gvrDeployment, case1FrameworkDeploymentName, addonNamespace, true, 30,
 			)
 			Expect(deploy).NotTo(BeNil())
 
-			By(cluster.clusterType + " " + cluster.clusterName +
-				": annotating the managedclusteraddon with the pause annotation")
+			By(logPrefix + "annotating the managedclusteraddon with the pause annotation")
 			Kubectl("annotate", "-n", cluster.clusterName, "-f", case1ManagedClusterAddOnCR, "policy-addon-pause=true")
 
-			By(cluster.clusterType + " " + cluster.clusterName +
-				": getting the default number of items in the ManifestWork")
+			By(logPrefix + "getting the default number of items in the ManifestWork")
 			defaultLength := 0
 			Eventually(func() int {
 				mw := GetWithTimeout(clientDynamic, gvrManifestWork, case1MWName, cluster.clusterName, true, 15)
@@ -287,11 +272,11 @@ var _ = Describe("Test framework deployment", func() {
 				return defaultLength
 			}, 60, 5).ShouldNot(Equal(0))
 
-			By(cluster.clusterType + " " + cluster.clusterName + ": patching the ManifestWork to add an item")
+			By(logPrefix + ": patching the ManifestWork to add an item")
 			Kubectl("patch", "-n", cluster.clusterName, "manifestwork", case1MWName, "--type=json",
 				"--patch-file="+case1MWPatch)
 
-			By(cluster.clusterType + " " + cluster.clusterName + ": verifying the edit is not reverted")
+			By(logPrefix + ": verifying the edit is not reverted")
 			Consistently(func() int {
 				mw := GetWithTimeout(clientDynamic, gvrManifestWork, case1MWName, cluster.clusterName, true, 15)
 				manifests, _, _ := unstructured.NestedSlice(mw.Object, "spec", "workload", "manifests")
@@ -299,7 +284,7 @@ var _ = Describe("Test framework deployment", func() {
 				return len(manifests)
 			}, 30, 5).Should(Equal(defaultLength + 1))
 
-			By(cluster.clusterType + " " + cluster.clusterName + ": deleting the managedclusteraddon")
+			By(logPrefix + ": deleting the managedclusteraddon")
 			Kubectl("delete", "-n", cluster.clusterName, "-f", case1ManagedClusterAddOnCR)
 			deploy = GetWithTimeout(
 				cluster.clusterClient, gvrDeployment, case1FrameworkDeploymentName, addonNamespace, false, 30,

--- a/test/e2e/case2_config_deployment_test.go
+++ b/test/e2e/case2_config_deployment_test.go
@@ -6,6 +6,7 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 )
 
 const (
@@ -68,7 +69,33 @@ var _ = Describe("Test config-policy-controller deployment", func() {
 				return getAddonStatus(addon)
 			}, 240, 1).Should(Equal(true))
 
-			By(logPrefix + "showing the config-policy-controller managedclusteraddon as available")
+			By(logPrefix + "annotating the managedclusteraddon with the " + loggingLevelAnnotation + " annotation")
+			Kubectl("annotate", "-n", cluster.clusterName, "-f", case2ManagedClusterAddOnCR, loggingLevelAnnotation)
+
+			By(cluster.clusterType + " " + cluster.clusterName + ": verifying a new config-policy-controller pod is deployed")
+			opts := metav1.ListOptions{
+				LabelSelector: case2PodSelector,
+			}
+			_ = ListWithTimeoutByNamespace(cluster.clusterClient, gvrPod, opts, addonNamespace, 2, true, 30)
+
+			By(logPrefix + "verifying the pod has been deployed with a new logging level")
+			pods := ListWithTimeoutByNamespace(cluster.clusterClient, gvrPod, opts, addonNamespace, 1, true, 60)
+			containerList, _, err := unstructured.NestedSlice(pods.Items[0].Object, "spec", "containers")
+			if err != nil {
+				panic(err)
+			}
+			for _, container := range containerList {
+				containerObj := container.(map[string]interface{})
+				if Expect(containerObj).To(HaveKey("name")) && containerObj["name"] != case2DeploymentName {
+					continue
+				}
+				if Expect(containerObj).To(HaveKey("args")) {
+					args := containerObj["args"]
+					Expect(args).To(ContainElement("--log-encoder=console"))
+					Expect(args).To(ContainElement("--log-level=8"))
+					Expect(args).To(ContainElement("--v=6"))
+				}
+			}
 
 			By(logPrefix + "removing the config-policy-controller deployment when the ManagedClusterAddOn CR is removed")
 			Kubectl("delete", "-n", cluster.clusterName, "-f", case2ManagedClusterAddOnCR)

--- a/test/e2e/case2_config_deployment_test.go
+++ b/test/e2e/case2_config_deployment_test.go
@@ -103,7 +103,7 @@ var _ = Describe("Test config-policy-controller deployment", func() {
 			By(logPrefix + "annotating the managedclusteraddon with the " + loggingLevelAnnotation + " annotation")
 			Kubectl("annotate", "-n", cluster.clusterName, "-f", case2ManagedClusterAddOnCR, loggingLevelAnnotation)
 
-			By(logPrefix + ": verifying a new config-policy-controller pod is deployed")
+			By(logPrefix + "verifying a new config-policy-controller pod is deployed")
 			opts := metav1.ListOptions{
 				LabelSelector: case2PodSelector,
 			}

--- a/test/e2e/case2_config_deployment_test.go
+++ b/test/e2e/case2_config_deployment_test.go
@@ -10,8 +10,8 @@ import (
 
 const (
 	case2ManagedClusterAddOnCR string = "../resources/config_policy_addon_cr.yaml"
-	case2ConfigDeploymentName  string = "config-policy-controller"
-	case2ConfigPodSelector     string = "app=config-policy-controller"
+	case2DeploymentName        string = "config-policy-controller"
+	case2PodSelector           string = "app=config-policy-controller"
 )
 
 var _ = Describe("Test config-policy-controller deployment", func() {
@@ -21,14 +21,14 @@ var _ = Describe("Test config-policy-controller deployment", func() {
 			By(logPrefix + "deploying the default config-policy-controller managedclusteraddon")
 			Kubectl("apply", "-n", cluster.clusterName, "-f", case2ManagedClusterAddOnCR)
 			deploy := GetWithTimeout(
-				cluster.clusterClient, gvrDeployment, case2ConfigDeploymentName, addonNamespace, true, 30,
+				cluster.clusterClient, gvrDeployment, case2DeploymentName, addonNamespace, true, 30,
 			)
 			Expect(deploy).NotTo(BeNil())
 
 			By(logPrefix + "checking the number of containers in the deployment")
 			Eventually(func() int {
 				deploy = GetWithTimeout(
-					cluster.clusterClient, gvrDeployment, case2ConfigDeploymentName, addonNamespace, true, 30,
+					cluster.clusterClient, gvrDeployment, case2DeploymentName, addonNamespace, true, 30,
 				)
 				spec := deploy.Object["spec"].(map[string]interface{})["template"].(map[string]interface{})["spec"]
 				containers := spec.(map[string]interface{})["containers"]
@@ -39,7 +39,7 @@ var _ = Describe("Test config-policy-controller deployment", func() {
 			By(logPrefix + "verifying all replicas in config-policy-controller deployment are available")
 			Eventually(func() bool {
 				deploy = GetWithTimeout(
-					cluster.clusterClient, gvrDeployment, case2ConfigDeploymentName, addonNamespace, true, 30,
+					cluster.clusterClient, gvrDeployment, case2DeploymentName, addonNamespace, true, 30,
 				)
 				status := deploy.Object["status"]
 				replicas := status.(map[string]interface{})["replicas"]
@@ -51,7 +51,7 @@ var _ = Describe("Test config-policy-controller deployment", func() {
 			By(logPrefix + "verifying a running config-policy-controller pod")
 			Eventually(func() bool {
 				opts := metav1.ListOptions{
-					LabelSelector: case2ConfigPodSelector,
+					LabelSelector: case2PodSelector,
 				}
 				pods := ListWithTimeoutByNamespace(cluster.clusterClient, gvrPod, opts, addonNamespace, 1, true, 30)
 				phase := pods.Items[0].Object["status"].(map[string]interface{})["phase"]
@@ -62,7 +62,7 @@ var _ = Describe("Test config-policy-controller deployment", func() {
 			By(logPrefix + "showing the config-policy-controller managedclusteraddon as available")
 			Eventually(func() bool {
 				addon := GetWithTimeout(
-					clientDynamic, gvrManagedClusterAddOn, case2ConfigDeploymentName, cluster.clusterName, true, 30,
+					clientDynamic, gvrManagedClusterAddOn, case2DeploymentName, cluster.clusterName, true, 30,
 				)
 
 				return getAddonStatus(addon)
@@ -73,7 +73,7 @@ var _ = Describe("Test config-policy-controller deployment", func() {
 			By(logPrefix + "removing the config-policy-controller deployment when the ManagedClusterAddOn CR is removed")
 			Kubectl("delete", "-n", cluster.clusterName, "-f", case2ManagedClusterAddOnCR)
 			deploy = GetWithTimeout(
-				cluster.clusterClient, gvrDeployment, case2ConfigDeploymentName, addonNamespace, false, 30,
+				cluster.clusterClient, gvrDeployment, case2DeploymentName, addonNamespace, false, 30,
 			)
 			Expect(deploy).To(BeNil())
 		}

--- a/test/e2e/case2_config_deployment_test.go
+++ b/test/e2e/case2_config_deployment_test.go
@@ -17,16 +17,15 @@ const (
 var _ = Describe("Test config-policy-controller deployment", func() {
 	It("should create the default config-policy-controller deployment on the managed cluster", func() {
 		for _, cluster := range managedClusterList {
-			By(cluster.clusterType + " " + cluster.clusterName +
-				": deploying the default config-policy-controller managedclusteraddon")
+			logPrefix := cluster.clusterType + " " + cluster.clusterName + ": "
+			By(logPrefix + "deploying the default config-policy-controller managedclusteraddon")
 			Kubectl("apply", "-n", cluster.clusterName, "-f", case2ManagedClusterAddOnCR)
 			deploy := GetWithTimeout(
 				cluster.clusterClient, gvrDeployment, case2ConfigDeploymentName, addonNamespace, true, 30,
 			)
 			Expect(deploy).NotTo(BeNil())
 
-			By(cluster.clusterType + " " + cluster.clusterName +
-				": checking the number of containers in the deployment")
+			By(logPrefix + "checking the number of containers in the deployment")
 			Eventually(func() int {
 				deploy = GetWithTimeout(
 					cluster.clusterClient, gvrDeployment, case2ConfigDeploymentName, addonNamespace, true, 30,
@@ -37,8 +36,7 @@ var _ = Describe("Test config-policy-controller deployment", func() {
 				return len(containers.([]interface{}))
 			}, 60, 1).Should(Equal(1))
 
-			By(cluster.clusterType + " " + cluster.clusterName +
-				": verifying all replicas in config-policy-controller deployment are available")
+			By(logPrefix + "verifying all replicas in config-policy-controller deployment are available")
 			Eventually(func() bool {
 				deploy = GetWithTimeout(
 					cluster.clusterClient, gvrDeployment, case2ConfigDeploymentName, addonNamespace, true, 30,
@@ -50,8 +48,7 @@ var _ = Describe("Test config-policy-controller deployment", func() {
 				return (availableReplicas != nil) && replicas.(int64) == availableReplicas.(int64)
 			}, 240, 1).Should(Equal(true))
 
-			By(cluster.clusterType + " " + cluster.clusterName +
-				": verifying a running config-policy-controller pod")
+			By(logPrefix + "verifying a running config-policy-controller pod")
 			Eventually(func() bool {
 				opts := metav1.ListOptions{
 					LabelSelector: case2ConfigPodSelector,
@@ -62,8 +59,7 @@ var _ = Describe("Test config-policy-controller deployment", func() {
 				return phase.(string) == "Running"
 			}, 60, 1).Should(Equal(true))
 
-			By(cluster.clusterType + " " + cluster.clusterName +
-				": showing the config-policy-controller managedclusteraddon as available")
+			By(logPrefix + "showing the config-policy-controller managedclusteraddon as available")
 			Eventually(func() bool {
 				addon := GetWithTimeout(
 					clientDynamic, gvrManagedClusterAddOn, case2ConfigDeploymentName, cluster.clusterName, true, 30,
@@ -72,8 +68,9 @@ var _ = Describe("Test config-policy-controller deployment", func() {
 				return getAddonStatus(addon)
 			}, 240, 1).Should(Equal(true))
 
-			By(cluster.clusterType + " " + cluster.clusterName +
-				": removing the config-policy-controller deployment when the ManagedClusterAddOn CR is removed")
+			By(logPrefix + "showing the config-policy-controller managedclusteraddon as available")
+
+			By(logPrefix + "removing the config-policy-controller deployment when the ManagedClusterAddOn CR is removed")
 			Kubectl("delete", "-n", cluster.clusterName, "-f", case2ManagedClusterAddOnCR)
 			deploy = GetWithTimeout(
 				cluster.clusterClient, gvrDeployment, case2ConfigDeploymentName, addonNamespace, false, 30,

--- a/test/e2e/case2_config_deployment_test.go
+++ b/test/e2e/case2_config_deployment_test.go
@@ -71,11 +71,39 @@ var _ = Describe("Test config-policy-controller deployment", func() {
 				return getAddonStatus(addon)
 			}, 240, 1).Should(Equal(true))
 
+			By(logPrefix +
+				"removing the config-policy-controller deployment when the ManagedClusterAddOn CR is removed")
+			Kubectl("delete", "-n", cluster.clusterName, "-f", case2ManagedClusterAddOnCR)
+			deploy = GetWithTimeout(
+				cluster.clusterClient, gvrDeployment, case2DeploymentName, addonNamespace, false, 30,
+			)
+			Expect(deploy).To(BeNil())
+		}
+	})
+
+	It("should create a config-policy-controller deployment with custom logging levels", func() {
+		for _, cluster := range managedClusterList {
+			logPrefix := cluster.clusterType + " " + cluster.clusterName + ": "
+			By(logPrefix + "deploying the default config-policy-controller managedclusteraddon")
+			Kubectl("apply", "-n", cluster.clusterName, "-f", case2ManagedClusterAddOnCR)
+			deploy := GetWithTimeout(
+				cluster.clusterClient, gvrDeployment, case2DeploymentName, addonNamespace, true, 30,
+			)
+			Expect(deploy).NotTo(BeNil())
+
+			By(logPrefix + "showing the config-policy-controller managedclusteraddon as available")
+			Eventually(func() bool {
+				addon := GetWithTimeout(
+					clientDynamic, gvrManagedClusterAddOn, case2DeploymentName, cluster.clusterName, true, 30,
+				)
+
+				return getAddonStatus(addon)
+			}, 240, 1).Should(Equal(true))
+
 			By(logPrefix + "annotating the managedclusteraddon with the " + loggingLevelAnnotation + " annotation")
 			Kubectl("annotate", "-n", cluster.clusterName, "-f", case2ManagedClusterAddOnCR, loggingLevelAnnotation)
 
-			By(cluster.clusterType + " " + cluster.clusterName +
-				": verifying a new config-policy-controller pod is deployed")
+			By(logPrefix + ": verifying a new config-policy-controller pod is deployed")
 			opts := metav1.ListOptions{
 				LabelSelector: case2PodSelector,
 			}
@@ -83,6 +111,9 @@ var _ = Describe("Test config-policy-controller deployment", func() {
 
 			By(logPrefix + "verifying the pod has been deployed with a new logging level")
 			pods := ListWithTimeoutByNamespace(cluster.clusterClient, gvrPod, opts, addonNamespace, 1, true, 60)
+			phase := pods.Items[0].Object["status"].(map[string]interface{})["phase"]
+
+			Expect(phase.(string)).To(Equal("Running"))
 			containerList, _, err := unstructured.NestedSlice(pods.Items[0].Object, "spec", "containers")
 			if err != nil {
 				panic(err)

--- a/test/e2e/case3_iam_deployment_test.go
+++ b/test/e2e/case3_iam_deployment_test.go
@@ -17,16 +17,15 @@ const (
 var _ = Describe("Test iam-policy-controller deployment", func() {
 	It("should create the iam-policy-controller deployment on the managed cluster", func() {
 		for _, cluster := range managedClusterList {
-			By(cluster.clusterType + " " + cluster.clusterName +
-				": deploying the default iam-policy-controller managedclusteraddon")
+			logPrefix := cluster.clusterType + " " + cluster.clusterName + ": "
+			By(logPrefix + "deploying the default iam-policy-controller managedclusteraddon")
 			Kubectl("apply", "-n", cluster.clusterName, "-f", case3ManagedClusterAddOnCR)
 			deploy := GetWithTimeout(
 				cluster.clusterClient, gvrDeployment, case3DeploymentName, addonNamespace, true, 30,
 			)
 			Expect(deploy).NotTo(BeNil())
 
-			By(cluster.clusterType + " " + cluster.clusterName +
-				": checking the number of containers in the deployment")
+			By(logPrefix + "checking the number of containers in the deployment")
 			Eventually(func() int {
 				deploy = GetWithTimeout(
 					cluster.clusterClient, gvrDeployment, case3DeploymentName, addonNamespace, true, 30,
@@ -37,8 +36,7 @@ var _ = Describe("Test iam-policy-controller deployment", func() {
 				return len(containers.([]interface{}))
 			}, 60, 1).Should(Equal(1))
 
-			By(cluster.clusterType + " " + cluster.clusterName +
-				": verifying all replicas in iam-policy-controller deployment are available")
+			By(logPrefix + "verifying all replicas in iam-policy-controller deployment are available")
 			Eventually(func() bool {
 				deploy = GetWithTimeout(
 					cluster.clusterClient, gvrDeployment, case3DeploymentName, addonNamespace, true, 30,
@@ -50,8 +48,7 @@ var _ = Describe("Test iam-policy-controller deployment", func() {
 				return (availableReplicas != nil) && replicas.(int64) == availableReplicas.(int64)
 			}, 240, 1).Should(Equal(true))
 
-			By(cluster.clusterType + " " + cluster.clusterName +
-				": verifying a running iam-policy-controller pod")
+			By(logPrefix + "verifying a running iam-policy-controller pod")
 			Eventually(func() bool {
 				opts := metav1.ListOptions{
 					LabelSelector: case3PodSelector,
@@ -62,8 +59,7 @@ var _ = Describe("Test iam-policy-controller deployment", func() {
 				return phase.(string) == "Running"
 			}, 60, 1).Should(Equal(true))
 
-			By(cluster.clusterType + " " + cluster.clusterName +
-				": showing the iam-policy-controller managedclusteraddon as available")
+			By(logPrefix + "showing the iam-policy-controller managedclusteraddon as available")
 			Eventually(func() bool {
 				addon := GetWithTimeout(
 					clientDynamic, gvrManagedClusterAddOn, case3DeploymentName, cluster.clusterName, true, 30,
@@ -72,8 +68,7 @@ var _ = Describe("Test iam-policy-controller deployment", func() {
 				return getAddonStatus(addon)
 			}, 240, 1).Should(Equal(true))
 
-			By(cluster.clusterType + " " + cluster.clusterName +
-				": removing the iam-policy-controller deployment when the ManagedClusterAddOn CR is removed")
+			By(logPrefix + "removing the iam-policy-controller deployment when the ManagedClusterAddOn CR is removed")
 			Kubectl("delete", "-n", cluster.clusterName, "-f", case3ManagedClusterAddOnCR)
 			deploy = GetWithTimeout(
 				cluster.clusterClient, gvrDeployment, case3DeploymentName, addonNamespace, false, 30,

--- a/test/e2e/case3_iam_deployment_test.go
+++ b/test/e2e/case3_iam_deployment_test.go
@@ -102,7 +102,7 @@ var _ = Describe("Test iam-policy-controller deployment", func() {
 			By(logPrefix + "annotating the managedclusteraddon with the " + loggingLevelAnnotation + " annotation")
 			Kubectl("annotate", "-n", cluster.clusterName, "-f", case3ManagedClusterAddOnCR, loggingLevelAnnotation)
 
-			By(logPrefix + ": verifying a new iam-policy-controller pod is deployed")
+			By(logPrefix + "verifying a new iam-policy-controller pod is deployed")
 			opts := metav1.ListOptions{
 				LabelSelector: case3PodSelector,
 			}

--- a/test/e2e/case3_iam_deployment_test.go
+++ b/test/e2e/case3_iam_deployment_test.go
@@ -3,6 +3,8 @@
 package e2e
 
 import (
+	"fmt"
+
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -72,7 +74,8 @@ var _ = Describe("Test iam-policy-controller deployment", func() {
 			By(logPrefix + "annotating the managedclusteraddon with the " + loggingLevelAnnotation + " annotation")
 			Kubectl("annotate", "-n", cluster.clusterName, "-f", case3ManagedClusterAddOnCR, loggingLevelAnnotation)
 
-			By(cluster.clusterType + " " + cluster.clusterName + ": verifying a new iam-policy-controller pod is deployed")
+			By(cluster.clusterType + " " + cluster.clusterName +
+				": verifying a new iam-policy-controller pod is deployed")
 			opts := metav1.ListOptions{
 				LabelSelector: case3PodSelector,
 			}
@@ -85,15 +88,18 @@ var _ = Describe("Test iam-policy-controller deployment", func() {
 				panic(err)
 			}
 			for _, container := range containerList {
-				containerObj := container.(map[string]interface{})
-				if Expect(containerObj).To(HaveKey("name")) && containerObj["name"] != case3DeploymentName {
-					continue
-				}
-				if Expect(containerObj).To(HaveKey("args")) {
-					args := containerObj["args"]
-					Expect(args).To(ContainElement("--log-encoder=console"))
-					Expect(args).To(ContainElement("--log-level=8"))
-					Expect(args).To(ContainElement("--v=6"))
+				if containerObj, ok := container.(map[string]interface{}); ok {
+					if Expect(containerObj).To(HaveKey("name")) && containerObj["name"] != case2DeploymentName {
+						continue
+					}
+					if Expect(containerObj).To(HaveKey("args")) {
+						args := containerObj["args"]
+						Expect(args).To(ContainElement("--log-encoder=console"))
+						Expect(args).To(ContainElement("--log-level=8"))
+						Expect(args).To(ContainElement("--v=6"))
+					}
+				} else {
+					panic(fmt.Errorf("containerObj type assertion failed"))
 				}
 			}
 

--- a/test/e2e/case4_cert_deployment_test.go
+++ b/test/e2e/case4_cert_deployment_test.go
@@ -102,7 +102,7 @@ var _ = Describe("Test cert-policy-controller deployment", func() {
 			By(logPrefix + "annotating the managedclusteraddon with the " + loggingLevelAnnotation + " annotation")
 			Kubectl("annotate", "-n", cluster.clusterName, "-f", case4ManagedClusterAddOnCR, loggingLevelAnnotation)
 
-			By(logPrefix + ": verifying a new cert-policy-controller pod is deployed")
+			By(logPrefix + "verifying a new cert-policy-controller pod is deployed")
 			opts := metav1.ListOptions{
 				LabelSelector: case4PodSelector,
 			}

--- a/test/e2e/case4_cert_deployment_test.go
+++ b/test/e2e/case4_cert_deployment_test.go
@@ -6,6 +6,7 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 )
 
 const (
@@ -67,6 +68,34 @@ var _ = Describe("Test cert-policy-controller deployment", func() {
 
 				return getAddonStatus(addon)
 			}, 240, 1).Should(Equal(true))
+
+			By(logPrefix + "annotating the managedclusteraddon with the " + loggingLevelAnnotation + " annotation")
+			Kubectl("annotate", "-n", cluster.clusterName, "-f", case4ManagedClusterAddOnCR, loggingLevelAnnotation)
+
+			By(cluster.clusterType + " " + cluster.clusterName + ": verifying a new cert-policy-controller pod is deployed")
+			opts := metav1.ListOptions{
+				LabelSelector: case4PodSelector,
+			}
+			_ = ListWithTimeoutByNamespace(cluster.clusterClient, gvrPod, opts, addonNamespace, 2, true, 30)
+
+			By(logPrefix + "verifying the pod has been deployed with a new logging level")
+			pods := ListWithTimeoutByNamespace(cluster.clusterClient, gvrPod, opts, addonNamespace, 1, true, 60)
+			containerList, _, err := unstructured.NestedSlice(pods.Items[0].Object, "spec", "containers")
+			if err != nil {
+				panic(err)
+			}
+			for _, container := range containerList {
+				containerObj := container.(map[string]interface{})
+				if Expect(containerObj).To(HaveKey("name")) && containerObj["name"] != case4DeploymentName {
+					continue
+				}
+				if Expect(containerObj).To(HaveKey("args")) {
+					args := containerObj["args"]
+					Expect(args).To(ContainElement("--log-encoder=console"))
+					Expect(args).To(ContainElement("--log-level=8"))
+					Expect(args).To(ContainElement("--v=6"))
+				}
+			}
 
 			By(logPrefix + "removing the cert-policy-controller deployment when the ManagedClusterAddOn CR is removed")
 			Kubectl("delete", "-n", cluster.clusterName, "-f", case4ManagedClusterAddOnCR)

--- a/test/e2e/case4_cert_deployment_test.go
+++ b/test/e2e/case4_cert_deployment_test.go
@@ -3,6 +3,8 @@
 package e2e
 
 import (
+	"fmt"
+
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -72,7 +74,8 @@ var _ = Describe("Test cert-policy-controller deployment", func() {
 			By(logPrefix + "annotating the managedclusteraddon with the " + loggingLevelAnnotation + " annotation")
 			Kubectl("annotate", "-n", cluster.clusterName, "-f", case4ManagedClusterAddOnCR, loggingLevelAnnotation)
 
-			By(cluster.clusterType + " " + cluster.clusterName + ": verifying a new cert-policy-controller pod is deployed")
+			By(cluster.clusterType + " " + cluster.clusterName +
+				": verifying a new cert-policy-controller pod is deployed")
 			opts := metav1.ListOptions{
 				LabelSelector: case4PodSelector,
 			}
@@ -85,15 +88,18 @@ var _ = Describe("Test cert-policy-controller deployment", func() {
 				panic(err)
 			}
 			for _, container := range containerList {
-				containerObj := container.(map[string]interface{})
-				if Expect(containerObj).To(HaveKey("name")) && containerObj["name"] != case4DeploymentName {
-					continue
-				}
-				if Expect(containerObj).To(HaveKey("args")) {
-					args := containerObj["args"]
-					Expect(args).To(ContainElement("--log-encoder=console"))
-					Expect(args).To(ContainElement("--log-level=8"))
-					Expect(args).To(ContainElement("--v=6"))
+				if containerObj, ok := container.(map[string]interface{}); ok {
+					if Expect(containerObj).To(HaveKey("name")) && containerObj["name"] != case2DeploymentName {
+						continue
+					}
+					if Expect(containerObj).To(HaveKey("args")) {
+						args := containerObj["args"]
+						Expect(args).To(ContainElement("--log-encoder=console"))
+						Expect(args).To(ContainElement("--log-level=8"))
+						Expect(args).To(ContainElement("--v=6"))
+					}
+				} else {
+					panic(fmt.Errorf("containerObj type assertion failed"))
 				}
 			}
 

--- a/test/e2e/case4_cert_deployment_test.go
+++ b/test/e2e/case4_cert_deployment_test.go
@@ -17,16 +17,15 @@ const (
 var _ = Describe("Test cert-policy-controller deployment", func() {
 	It("should create the cert-policy-controller deployment on the managed cluster", func() {
 		for _, cluster := range managedClusterList {
-			By(cluster.clusterType + " " + cluster.clusterName +
-				": deploying the default cert-policy-controller managedclusteraddon")
+			logPrefix := cluster.clusterType + " " + cluster.clusterName + ": "
+			By(logPrefix + "deploying the default cert-policy-controller managedclusteraddon")
 			Kubectl("apply", "-n", cluster.clusterName, "-f", case4ManagedClusterAddOnCR)
 			deploy := GetWithTimeout(
 				cluster.clusterClient, gvrDeployment, case4DeploymentName, addonNamespace, true, 30,
 			)
 			Expect(deploy).NotTo(BeNil())
 
-			By(cluster.clusterType + " " + cluster.clusterName +
-				": checking the number of containers in the deployment")
+			By(logPrefix + "checking the number of containers in the deployment")
 			Eventually(func() int {
 				deploy = GetWithTimeout(
 					cluster.clusterClient, gvrDeployment, case4DeploymentName, addonNamespace, true, 30,
@@ -37,8 +36,7 @@ var _ = Describe("Test cert-policy-controller deployment", func() {
 				return len(containers.([]interface{}))
 			}, 60, 1).Should(Equal(1))
 
-			By(cluster.clusterType + " " + cluster.clusterName +
-				": verifying all replicas in cert-policy-controller deployment are available")
+			By(logPrefix + "verifying all replicas in cert-policy-controller deployment are available")
 			Eventually(func() bool {
 				deploy = GetWithTimeout(
 					cluster.clusterClient, gvrDeployment, case4DeploymentName, addonNamespace, true, 30,
@@ -50,8 +48,7 @@ var _ = Describe("Test cert-policy-controller deployment", func() {
 				return (availableReplicas != nil) && replicas.(int64) == availableReplicas.(int64)
 			}, 240, 1).Should(Equal(true))
 
-			By(cluster.clusterType + " " + cluster.clusterName +
-				": verifying a running cert-policy-controller pod")
+			By(logPrefix + "verifying a running cert-policy-controller pod")
 			Eventually(func() bool {
 				opts := metav1.ListOptions{
 					LabelSelector: case4PodSelector,
@@ -62,8 +59,7 @@ var _ = Describe("Test cert-policy-controller deployment", func() {
 				return phase.(string) == "Running"
 			}, 60, 1).Should(Equal(true))
 
-			By(cluster.clusterType + " " + cluster.clusterName +
-				": showing the cert-policy-controller managedclusteraddon as available")
+			By(logPrefix + "showing the cert-policy-controller managedclusteraddon as available")
 			Eventually(func() bool {
 				addon := GetWithTimeout(
 					clientDynamic, gvrManagedClusterAddOn, case4DeploymentName, cluster.clusterName, true, 30,
@@ -72,8 +68,7 @@ var _ = Describe("Test cert-policy-controller deployment", func() {
 				return getAddonStatus(addon)
 			}, 240, 1).Should(Equal(true))
 
-			By(cluster.clusterType + " " + cluster.clusterName +
-				": removing the cert-policy-controller deployment when the ManagedClusterAddOn CR is removed")
+			By(logPrefix + "removing the cert-policy-controller deployment when the ManagedClusterAddOn CR is removed")
 			Kubectl("delete", "-n", cluster.clusterName, "-f", case4ManagedClusterAddOnCR)
 			deploy = GetWithTimeout(
 				cluster.clusterClient, gvrDeployment, case4DeploymentName, addonNamespace, false, 30,

--- a/test/e2e/e2e_suite_test.go
+++ b/test/e2e/e2e_suite_test.go
@@ -21,8 +21,9 @@ import (
 )
 
 const (
-	addonNamespace     string = "open-cluster-management-agent-addon"
-	kubeconfigFilename string = "../../policy-addon-ctrl"
+	addonNamespace         string = "open-cluster-management-agent-addon"
+	kubeconfigFilename     string = "../../policy-addon-ctrl"
+	loggingLevelAnnotation string = "log-level=8"
 )
 
 var (


### PR DESCRIPTION
- Uses the new `--log-level` and `--log-encoder` flags to set a default logging level for all controllers
- Sets package logging (configurable with `--v`) to be two levels less than the component logging level
- Default settings:
  ```
  --log-encoder=console
  --log-level=0
  --v=-1
  ```

Addresses:
- https://github.com/stolostron/backlog/issues/19030