### PR TITLE
Remove framework's permissions for namespaces

### DIFF
--- a/pkg/addon/policyframework/manifests/managedclusterchart/templates/cluster_role.yaml
+++ b/pkg/addon/policyframework/manifests/managedclusterchart/templates/cluster_role.yaml
@@ -15,7 +15,6 @@ rules:
   - ""
   resources:
   - events
-  - namespaces
   verbs:
   - create
   - delete


### PR DESCRIPTION
The framework controllers no longer manage the cluster namespace on
managed clusters, so this permission is unnecessary now.

Refs:
 - https://github.com/stolostron/backlog/issues/20826

Signed-off-by: Justin Kulikauskas <jkulikau@redhat.com>