### PR TITLE
Add legacy leader election arg to template-sync

### DIFF
--- a/pkg/addon/policyframework/manifests/managedclusterchart/templates/deployment.yaml
+++ b/pkg/addon/policyframework/manifests/managedclusterchart/templates/deployment.yaml
@@ -145,6 +145,9 @@ spec:
         imagePullPolicy: "{{ .Values.global.imagePullPolicy }}"
         command: ["governance-policy-template-sync"]
         args:
+          {{- if semverCompare "< 1.14.0" .Capabilities.KubeVersion.Version }}
+          - --legacy-leader-elect=true
+          {{- end }}
           - --log-encoder={{ .Values.args.logEncoder }}
           - --log-level={{ .Values.args.logLevel }}
           - --v={{ .Values.args.pkgLogLevel }}


### PR DESCRIPTION
Not sure how this was missing before, but we found a bug because of it
on an OCP 3.11 cluster.

Signed-off-by: Justin Kulikauskas <jkulikau@redhat.com>