### PR TITLE
Add volume mounts for hub kubeconfig

### DIFF
--- a/pkg/addon/certpolicy/manifests/managedclusterchart/templates/deployment.yaml
+++ b/pkg/addon/certpolicy/manifests/managedclusterchart/templates/deployment.yaml
@@ -80,6 +80,13 @@ spec:
             - ALL
           privileged: false
           readOnlyRootFilesystem: true
+        volumeMounts:
+          - name: klusterlet-config
+            mountPath: /var/run/klusterlet
+      volumes:
+        - name: klusterlet-config
+          secret:
+            secretName: {{ .Values.hubKubeConfigSecret }}
       {{- if .Values.global.imagePullSecret }}
       imagePullSecrets:
       - name: {{ .Values.global.imagePullSecret }}

--- a/pkg/addon/certpolicy/manifests/managedclusterchart/values.yaml
+++ b/pkg/addon/certpolicy/manifests/managedclusterchart/values.yaml
@@ -11,6 +11,7 @@ args:
   logLevel: 0
   pkgLogLevel: -1
   logEncoder: console
+hubKubeConfigSecret: cert-policy-controller-hub-kubeconfig
 
 resources:
   requests:

--- a/pkg/addon/configpolicy/manifests/managedclusterchart/templates/deployment.yaml
+++ b/pkg/addon/configpolicy/manifests/managedclusterchart/templates/deployment.yaml
@@ -67,6 +67,9 @@ spec:
           - ALL
         privileged: false
         readOnlyRootFilesystem: true
+        volumeMounts:
+          - name: klusterlet-config
+            mountPath: /var/run/klusterlet
       volumes:
         - name: klusterlet-config
           secret:

--- a/pkg/addon/iampolicy/manifests/managedclusterchart/templates/deployment.yaml
+++ b/pkg/addon/iampolicy/manifests/managedclusterchart/templates/deployment.yaml
@@ -80,9 +80,14 @@ spec:
         volumeMounts:
         - name: tmp
           mountPath: "/tmp"
+        - name: klusterlet-config
+          mountPath: /var/run/klusterlet
       volumes:
       - name: tmp
         emptyDir: {}
+      - name: klusterlet-config
+        secret:
+          secretName: {{ .Values.hubKubeConfigSecret }}
       {{- if .Values.global.imagePullSecret }}
       imagePullSecrets:
       - name: {{ .Values.global.imagePullSecret }}

--- a/pkg/addon/iampolicy/manifests/managedclusterchart/values.yaml
+++ b/pkg/addon/iampolicy/manifests/managedclusterchart/values.yaml
@@ -15,6 +15,7 @@ securityContext:
   allowPrivilegeEscalation: false
   readOnlyRootFilesystem: true
   runAsNonRoot: true
+hubKubeConfigSecret: iam-policy-controller-hub-kubeconfig
 
 resources:
   requests:


### PR DESCRIPTION
The policy controllers were reading the hub kubeconfig from the secret
more "manually" before, which meant that the configs were not being
updated after they expired and the secret was updated. This mounts the
config through a secret, which is automagically updated.

Refs:
 - https://github.com/stolostron/backlog/issues/22651

Signed-off-by: Justin Kulikauskas <jkulikau@redhat.com>