### PR TITLE
Use new linting for go 1.18

### DIFF
--- a/.github/workflows/kind.yml
+++ b/.github/workflows/kind.yml
@@ -19,7 +19,7 @@ jobs:
     strategy:
       matrix:
         go:
-          - '1.17'
+          - '1.18'
         # Run tests on oldest and newest supported OCP Kubernetes
         # - OCP 4.5 runs Kubernetes v1.18
         # KinD tags: https://hub.docker.com/r/kindest/node/tags

--- a/Makefile
+++ b/Makefile
@@ -250,7 +250,7 @@ fmt: fmt-dependencies
 
 ##@ Quality Control
 lint-dependencies:
-	$(call go-get-tool,github.com/golangci/golangci-lint/cmd/golangci-lint@v1.41.1)
+	$(call go-get-tool,github.com/golangci/golangci-lint/cmd/golangci-lint@v1.46.2)
 
 # All available linters: lint-dockerfiles lint-scripts lint-yaml lint-copyright-banner lint-go lint-python lint-helm lint-markdown lint-sass lint-typescript lint-protos
 # Default value will run all linters, override these make target with your requirements:

--- a/build/common/config/.golangci.yml
+++ b/build/common/config/.golangci.yml
@@ -4,6 +4,7 @@ service:
 run:
   # timeout for analysis, e.g. 30s, 5m, default is 1m
   deadline: 20m
+  go: '1.17'
   timeout: 20m
 
   # which dirs to skip: they won't be analyzed;
@@ -28,11 +29,15 @@ linters:
   enable-all: true
   disable:
     - bodyclose
+    - contextcheck # New linter to consider
     - cyclop
     - depguard
     - dupl
     - funlen
+    - exhaustruct
     - exhaustivestruct
+    - forcetypeassert
+    - gci # disable until it's more configurable
     - gochecknoglobals
     - gochecknoinits
     - gocognit
@@ -40,18 +45,24 @@ linters:
     - gocyclo
     - godot
     - goerr113
+    - golint # replaced by revive
     - gomnd
     - gomoddirectives
     - gosec
     - ifshort
     - interfacer
+    - ireturn # New linter to consider
+    - maintidx # New linter to consider
     - maligned
     - nakedret
     - nestif
+    - nilnil # New linter to consider
+    - nonamedreturns # New linter to consider
     - paralleltest
     - prealloc
     - scopelint
     - testpackage
+    - varnamelen # New linter to consider
     - wrapcheck
   fast: false
 
@@ -68,7 +79,8 @@ linters-settings:
     # report about shadowed variables
     check-shadowing: false
   gci:
-    local-prefixes: open-cluster-management.io/governance-policy-addon-controller
+    sections:
+      - prefix(open-cluster-management.io/governance-policy-addon-controller)
   golint:
     # minimal confidence for issues, default is 0.8
     min-confidence: 0.0

--- a/pkg/addon/certpolicy/agent_addon.go
+++ b/pkg/addon/certpolicy/agent_addon.go
@@ -32,7 +32,8 @@ var agentPermissionFiles = []string{
 }
 
 func getValues(cluster *clusterv1.ManagedCluster,
-	addon *addonapiv1alpha1.ManagedClusterAddOn) (addonfactory.Values, error) {
+	addon *addonapiv1alpha1.ManagedClusterAddOn,
+) (addonfactory.Values, error) {
 	userValues := policyaddon.UserValues{
 		GlobalValues: policyaddon.GlobalValues{
 			ImagePullPolicy: "IfNotPresent",

--- a/pkg/addon/configpolicy/agent_addon.go
+++ b/pkg/addon/configpolicy/agent_addon.go
@@ -32,7 +32,8 @@ var agentPermissionFiles = []string{
 }
 
 func getValues(cluster *clusterv1.ManagedCluster,
-	addon *addonapiv1alpha1.ManagedClusterAddOn) (addonfactory.Values, error) {
+	addon *addonapiv1alpha1.ManagedClusterAddOn,
+) (addonfactory.Values, error) {
 	userValues := policyaddon.UserValues{
 		GlobalValues: policyaddon.GlobalValues{
 			ImagePullPolicy: "IfNotPresent",

--- a/pkg/addon/iampolicy/agent_addon.go
+++ b/pkg/addon/iampolicy/agent_addon.go
@@ -32,7 +32,8 @@ var agentPermissionFiles = []string{
 }
 
 func getValues(cluster *clusterv1.ManagedCluster,
-	addon *addonapiv1alpha1.ManagedClusterAddOn) (addonfactory.Values, error) {
+	addon *addonapiv1alpha1.ManagedClusterAddOn,
+) (addonfactory.Values, error) {
 	userValues := policyaddon.UserValues{
 		GlobalValues: policyaddon.GlobalValues{
 			ImagePullPolicy: "IfNotPresent",

--- a/pkg/addon/policyframework/agent_addon.go
+++ b/pkg/addon/policyframework/agent_addon.go
@@ -39,7 +39,8 @@ type userValues struct {
 }
 
 func getValues(cluster *clusterv1.ManagedCluster,
-	addon *addonapiv1alpha1.ManagedClusterAddOn) (addonfactory.Values, error) {
+	addon *addonapiv1alpha1.ManagedClusterAddOn,
+) (addonfactory.Values, error) {
 	userValues := userValues{
 		OnMulticlusterHub: false,
 		GlobalValues: policyaddon.GlobalValues{


### PR DESCRIPTION
New linting changes are required for go 1.18.

This is a fix for https://github.com/stolostron/governance-policy-addon-controller/issues/48

Signed-off-by: Gus Parvin <gparvin@redhat.com>