### PR TITLE
Use the latest-2.6 image tag

### DIFF
--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -39,17 +39,17 @@ spec:
             fieldRef:
               fieldPath: metadata.name
         - name: CERT_POLICY_CONTROLLER_IMAGE
-          value: quay.io/stolostron/cert-policy-controller:latest
+          value: quay.io/stolostron/cert-policy-controller:latest-2.6
         - name: IAM_POLICY_CONTROLLER_IMAGE
-          value: quay.io/stolostron/iam-policy-controller:latest
+          value: quay.io/stolostron/iam-policy-controller:latest-2.6
         - name: CONFIG_POLICY_CONTROLLER_IMAGE
-          value: quay.io/stolostron/config-policy-controller:latest
+          value: quay.io/stolostron/config-policy-controller:latest-2.6
         - name: GOVERNANCE_POLICY_SPEC_SYNC_IMAGE
-          value: quay.io/stolostron/governance-policy-spec-sync:latest
+          value: quay.io/stolostron/governance-policy-spec-sync:latest-2.6
         - name: GOVERNANCE_POLICY_STATUS_SYNC_IMAGE
-          value: quay.io/stolostron/governance-policy-status-sync:latest
+          value: quay.io/stolostron/governance-policy-status-sync:latest-2.6
         - name: GOVERNANCE_POLICY_TEMPLATE_SYNC_IMAGE
-          value: quay.io/stolostron/governance-policy-template-sync:latest
+          value: quay.io/stolostron/governance-policy-template-sync:latest-2.6
         name: manager
         securityContext:
           allowPrivilegeEscalation: false


### PR DESCRIPTION
This ensures that the release-2.6 branch will use the 2.6 addon
container images.

This PR blocks #52.