### PR TITLE
Retry prow build due to failure in last image build

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,5 +125,5 @@ The e2e tests are intended to be run against a `kind` cluster. After setting one
 above (and waiting for the work-agent), the tests can be run with the `e2e-test` make target.
 
 <!---
-Date: 09/14/2022
+Date: 09/15/2022
 -->


### PR DESCRIPTION
A few prow image builds failed yesterday.  Didn't look into why so hoping a retry fixes it.

Refs:
 - https://coreos.slack.com/archives/C02UXRV7QP8/p1663222190238259

Signed-off-by: Gus Parvin <gparvin@redhat.com>