### PR TITLE
Add hosted mode support to cert policy in addon controller

### DIFF
--- a/pkg/addon/certpolicy/agent_addon.go
+++ b/pkg/addon/certpolicy/agent_addon.go
@@ -75,6 +75,7 @@ func GetAgentAddon(controllerContext *controllercmd.ControllerContext) (agent.Ag
 	return addonfactory.NewAgentAddonFactory(addonName, FS, "manifests/managedclusterchart").
 		WithGetValuesFuncs(getValues, addonfactory.GetValuesFromAddonAnnotation).
 		WithAgentRegistrationOption(registrationOption).
+		WithAgentHostedModeEnabledOption().
 		BuildHelmAgentAddon()
 }
 

--- a/pkg/addon/certpolicy/manifests/managedclusterchart/templates/cluster_role.yaml
+++ b/pkg/addon/certpolicy/manifests/managedclusterchart/templates/cluster_role.yaml
@@ -1,16 +1,68 @@
 # Copyright Contributors to the Open Cluster Management project
 
 apiVersion: rbac.authorization.k8s.io/v1
+{{- if eq .Values.installMode "Hosted" }}
+kind: Role
+{{- else }}
 kind: ClusterRole
+{{- end }}
 metadata:
   creationTimestamp: null
   name: {{ include "controller.rolename" . }}
+  {{- if eq .Values.installMode "Hosted" }}
+  namespace: {{ .Release.Namespace }}
+  {{- end }}
   labels:
     app: {{ include "controller.fullname" . }}
     chart: {{ include "controller.chart" . }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
+    addon.open-cluster-management.io/hosted-manifest-location: hosting
 rules:
+{{- if eq .Values.installMode "Hosted" }}
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - get
+  - list
+- apiGroups:
+  - policy.open-cluster-management.io
+  resources:
+  - certificatepolicies
+  verbs:
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - policy.open-cluster-management.io
+  resources:
+  - certificatepolicies/finalizers
+  verbs:
+  - update
+- apiGroups:
+  - policy.open-cluster-management.io
+  resources:
+  - certificatepolicies/status
+  verbs:
+  - get
+  - patch
+  - update
+{{- else }}
 - apiGroups:
   - ""
   resources:
@@ -57,3 +109,4 @@ rules:
   - get
   - patch
   - update
+{{- end }}

--- a/pkg/addon/certpolicy/manifests/managedclusterchart/templates/cluster_role_binding.yaml
+++ b/pkg/addon/certpolicy/manifests/managedclusterchart/templates/cluster_role_binding.yaml
@@ -1,18 +1,30 @@
 # Copyright Contributors to the Open Cluster Management project
 
 apiVersion: rbac.authorization.k8s.io/v1
+{{- if eq .Values.installMode "Hosted" }}
+kind: RoleBinding
+{{- else }}
 kind: ClusterRoleBinding
+{{- end }}
 metadata:
   creationTimestamp: null
   name: {{ include "controller.rolename" . }}
+  {{- if eq .Values.installMode "Hosted" }}
+  namespace: {{ .Release.Namespace }}
+  {{- end }}
   labels:
     app: {{ include "controller.fullname" . }}
     chart: {{ include "controller.chart" . }}
     release: {{ .Release.Name }}
-    heritage: {{ .Release.Service }}  
+    heritage: {{ .Release.Service }}
+    addon.open-cluster-management.io/hosted-manifest-location: hosting
 roleRef:
   apiGroup: rbac.authorization.k8s.io
+  {{- if eq .Values.installMode "Hosted" }}
+  kind: Role
+  {{- else }}
   kind: ClusterRole
+  {{- end }}
   name: {{ include "controller.rolename" . }}
 subjects:
 - kind: ServiceAccount

--- a/pkg/addon/certpolicy/manifests/managedclusterchart/templates/deployment.yaml
+++ b/pkg/addon/certpolicy/manifests/managedclusterchart/templates/deployment.yaml
@@ -10,6 +10,7 @@ metadata:
     chart: {{ include "controller.chart" . }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
+    addon.open-cluster-management.io/hosted-manifest-location: hosting
 spec:
   replicas: {{ .Values.replicas }}
   selector:
@@ -47,9 +48,16 @@ spec:
         - --log-encoder={{ .Values.args.logEncoder }}
         - --log-level={{ .Values.args.logLevel }}
         - --v={{ .Values.args.pkgLogLevel }}
+        {{- if eq .Values.installMode "Hosted" }}
+        - --target-kubeconfig-path=/var/run/managed-kubeconfig/kubeconfig
+        {{- end }}
         env:
         - name: WATCH_NAMESPACE
-          value: "{{ .Values.clusterName }}"
+          {{- if eq .Values.installMode "Hosted" }}
+          value: {{ .Release.Namespace }}
+          {{- else }}
+          value: {{ .Values.clusterName }}
+          {{- end }}
         - name: POD_NAME
           valueFrom:
             fieldRef:
@@ -102,10 +110,20 @@ spec:
         volumeMounts:
           - name: klusterlet-config
             mountPath: /var/run/klusterlet
+          {{- if eq .Values.installMode "Hosted" }}
+          - mountPath: "/var/run/managed-kubeconfig"
+            name: managed-kubeconfig-secret
+            readOnly: true
+          {{- end }}
       volumes:
         - name: klusterlet-config
           secret:
             secretName: {{ .Values.hubKubeConfigSecret }}
+        {{- if eq .Values.installMode "Hosted" }}
+        - name: managed-kubeconfig-secret
+          secret:
+            secretName: {{ .Values.managedKubeConfigSecret }}
+        {{- end }}
       {{- if .Values.global.imagePullSecret }}
       imagePullSecrets:
       - name: {{ .Values.global.imagePullSecret }}

--- a/pkg/addon/certpolicy/manifests/managedclusterchart/templates/install-namespace.yaml
+++ b/pkg/addon/certpolicy/manifests/managedclusterchart/templates/install-namespace.yaml
@@ -1,0 +1,11 @@
+# Copyright Contributors to the Open Cluster Management project
+
+{{- if ne .Release.Namespace "open-cluster-management-agent-addon" }}
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: {{ .Release.Namespace }}
+  labels:
+    addon.open-cluster-management.io/namespace: "true"
+    addon.open-cluster-management.io/hosted-manifest-location: hosting
+{{- end }}

--- a/pkg/addon/certpolicy/manifests/managedclusterchart/templates/leader_election_role.yaml
+++ b/pkg/addon/certpolicy/manifests/managedclusterchart/templates/leader_election_role.yaml
@@ -11,6 +11,7 @@ metadata:
     chart: {{ include "controller.chart" . }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
+    addon.open-cluster-management.io/hosted-manifest-location: hosting
 rules:
 - apiGroups:
   - ""

--- a/pkg/addon/certpolicy/manifests/managedclusterchart/templates/leader_election_role_binding.yaml
+++ b/pkg/addon/certpolicy/manifests/managedclusterchart/templates/leader_election_role_binding.yaml
@@ -10,6 +10,7 @@ metadata:
     chart: {{ include "controller.chart" . }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
+    addon.open-cluster-management.io/hosted-manifest-location: hosting
 subjects:
 - kind: ServiceAccount
   name: {{ include "controller.serviceAccountName" . }}

--- a/pkg/addon/certpolicy/manifests/managedclusterchart/templates/policy.open-cluster-management.io_certificatepolicy_crd.yaml
+++ b/pkg/addon/certpolicy/manifests/managedclusterchart/templates/policy.open-cluster-management.io_certificatepolicy_crd.yaml
@@ -8,6 +8,8 @@ metadata:
     controller-gen.kubebuilder.io/version: v0.6.1
   creationTimestamp: null
   name: certificatepolicies.policy.open-cluster-management.io
+  labels:
+    addon.open-cluster-management.io/hosted-manifest-location: hosting
 spec:
   group: policy.open-cluster-management.io
   names:

--- a/pkg/addon/certpolicy/manifests/managedclusterchart/templates/service_account.yaml
+++ b/pkg/addon/certpolicy/manifests/managedclusterchart/templates/service_account.yaml
@@ -10,6 +10,7 @@ metadata:
     chart: {{ include "controller.chart" . }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
+    addon.open-cluster-management.io/hosted-manifest-location: hosting
 {{- if .Values.global.imagePullSecret }}
 imagePullSecrets:
 - name: {{ .Values.global.imagePullSecret }}

--- a/pkg/addon/certpolicy/manifests/managedclusterchart/values.yaml
+++ b/pkg/addon/certpolicy/manifests/managedclusterchart/values.yaml
@@ -35,6 +35,7 @@ tolerations:
   effect: NoSchedule
 
 clusterName: null
+managedKubeConfigSecret: null
 
 global:
   imagePullPolicy: IfNotPresent

--- a/test/e2e/case4_cert_deployment_test.go
+++ b/test/e2e/case4_cert_deployment_test.go
@@ -3,10 +3,15 @@
 package e2e
 
 import (
+	"context"
+	"fmt"
+
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/client-go/dynamic"
 )
 
 const (
@@ -15,74 +20,170 @@ const (
 	case4PodSelector           string = "app=cert-policy-controller"
 )
 
+func verifyCertPolicyDeployment(
+	logPrefix string, client dynamic.Interface, clusterName, namespace string, clusterNum int,
+) {
+	By(logPrefix + "checking the number of containers in the deployment")
+
+	deploy := GetWithTimeout(
+		client, gvrDeployment, case4DeploymentName, namespace, true, 60,
+	)
+	Expect(deploy).NotTo(BeNil())
+
+	Eventually(func() int {
+		deploy = GetWithTimeout(
+			client, gvrDeployment, case4DeploymentName, namespace, true, 30,
+		)
+		containers, _, _ := unstructured.NestedSlice(deploy.Object, "spec", "template", "spec", "containers")
+
+		return len(containers)
+	}, 60, 1).Should(Equal(1))
+
+	if startupProbeInCluster(clusterNum) {
+		By(logPrefix + "verifying all replicas in cert-policy-controller deployment are available")
+		Eventually(func() bool {
+			deploy = GetWithTimeout(
+				client, gvrDeployment, case4DeploymentName, namespace, true, 30,
+			)
+			replicas, found, err := unstructured.NestedInt64(deploy.Object, "status", "replicas")
+			if !found || err != nil {
+				return false
+			}
+
+			available, found, err := unstructured.NestedInt64(deploy.Object, "status", "availableReplicas")
+			if !found || err != nil {
+				return false
+			}
+
+			return available == replicas
+		}, 240, 1).Should(Equal(true))
+	}
+
+	By(logPrefix + "verifying a running cert-policy-controller pod")
+	Eventually(func() bool {
+		opts := metav1.ListOptions{
+			LabelSelector: case4PodSelector,
+		}
+		pods := ListWithTimeoutByNamespace(client, gvrPod, opts, namespace, 1, true, 30)
+		phase, _, _ := unstructured.NestedString(pods.Items[0].Object, "status", "phase")
+
+		return phase == "Running"
+	}, 60, 1).Should(Equal(true))
+
+	By(logPrefix + "showing the cert-policy-controller managedclusteraddon as available")
+	Eventually(func() bool {
+		addon := GetWithTimeout(
+			clientDynamic, gvrManagedClusterAddOn, case4DeploymentName, clusterName, true, 30,
+		)
+
+		return getAddonStatus(addon)
+	}, 240, 1).Should(Equal(true))
+}
+
 var _ = Describe("Test cert-policy-controller deployment", func() {
-	It("should create the cert-policy-controller deployment on the managed cluster", func() {
+	It("should create the default cert-policy-controller deployment on the managed cluster", func() {
 		for i, cluster := range managedClusterList {
 			logPrefix := cluster.clusterType + " " + cluster.clusterName + ": "
 			By(logPrefix + "deploying the default cert-policy-controller managedclusteraddon")
 			Kubectl("apply", "-n", cluster.clusterName, "-f", case4ManagedClusterAddOnCR)
-			deploy := GetWithTimeout(
-				cluster.clusterClient, gvrDeployment, case4DeploymentName, addonNamespace, true, 30,
-			)
-			Expect(deploy).NotTo(BeNil())
 
-			By(logPrefix + "checking the number of containers in the deployment")
-			Eventually(func() int {
-				deploy = GetWithTimeout(
-					cluster.clusterClient, gvrDeployment, case4DeploymentName, addonNamespace, true, 30,
-				)
-				spec := deploy.Object["spec"].(map[string]interface{})["template"].(map[string]interface{})["spec"]
-				containers := spec.(map[string]interface{})["containers"]
-
-				return len(containers.([]interface{}))
-			}, 60, 1).Should(Equal(1))
-
-			if startupProbeInCluster(i) {
-				By(logPrefix + "verifying all replicas in cert-policy-controller deployment are available")
-				Eventually(func() bool {
-					deploy = GetWithTimeout(
-						cluster.clusterClient, gvrDeployment, case4DeploymentName, addonNamespace, true, 30,
-					)
-					replicas, found, err := unstructured.NestedInt64(deploy.Object, "status", "replicas")
-					if !found || err != nil {
-						return false
-					}
-
-					available, found, err := unstructured.NestedInt64(deploy.Object, "status", "availableReplicas")
-					if !found || err != nil {
-						return false
-					}
-
-					return available == replicas
-				}, 240, 1).Should(Equal(true))
-			}
-
-			By(logPrefix + "verifying a running cert-policy-controller pod")
-			Eventually(func() bool {
-				opts := metav1.ListOptions{
-					LabelSelector: case4PodSelector,
-				}
-				pods := ListWithTimeoutByNamespace(cluster.clusterClient, gvrPod, opts, addonNamespace, 1, true, 30)
-				phase, _, _ := unstructured.NestedString(pods.Items[0].Object, "status", "phase")
-
-				return phase == "Running"
-			}, 60, 1).Should(Equal(true))
-
-			By(logPrefix + "showing the cert-policy-controller managedclusteraddon as available")
-			Eventually(func() bool {
-				addon := GetWithTimeout(
-					clientDynamic, gvrManagedClusterAddOn, case4DeploymentName, cluster.clusterName, true, 30,
-				)
-
-				return getAddonStatus(addon)
-			}, 240, 1).Should(Equal(true))
+			verifyCertPolicyDeployment(logPrefix, cluster.clusterClient, cluster.clusterName, addonNamespace, i)
 
 			By(logPrefix + "removing the cert-policy-controller deployment when the ManagedClusterAddOn CR is removed")
 			Kubectl("delete", "-n", cluster.clusterName, "-f", case4ManagedClusterAddOnCR)
-			deploy = GetWithTimeout(
+			deploy := GetWithTimeout(
 				cluster.clusterClient, gvrDeployment, case4DeploymentName, addonNamespace, false, 30,
 			)
 			Expect(deploy).To(BeNil())
+		}
+	})
+
+	It("should create the default cert-policy-controller deployment in hosted mode", Label("hosted-mode"), func() {
+		for i, cluster := range managedClusterList[1:] {
+			Expect(cluster.clusterType).To(Equal("managed"))
+
+			cluster = managedClusterConfig{
+				clusterClient: cluster.clusterClient,
+				clusterName:   cluster.clusterName,
+				clusterType:   cluster.clusterType,
+				hostedOnHub:   true,
+			}
+			hubClusterConfig := managedClusterList[0]
+			hubClient := hubClusterConfig.clusterClient
+			installNamespace := fmt.Sprintf("%s-hosted", cluster.clusterName)
+			logPrefix := cluster.clusterType + " " + cluster.clusterName + ": "
+
+			By(logPrefix + "creating the cert-policy-controller-managed-kubeconfig secret")
+			installNamespaceObject := unstructured.Unstructured{Object: map[string]interface{}{
+				"apiVersion": "v1",
+				"kind":       "Namespace",
+				"metadata": map[string]interface{}{
+					"name": installNamespace,
+				},
+			}}
+
+			_, err := hubClient.Resource(gvrNamespace).Create(
+				context.TODO(), &installNamespaceObject, metav1.CreateOptions{},
+			)
+			if !errors.IsAlreadyExists(err) {
+				Expect(err).To(BeNil())
+			}
+
+			secret := unstructured.Unstructured{Object: map[string]interface{}{
+				"apiVersion": "v1",
+				"kind":       "Secret",
+				"metadata": map[string]interface{}{
+					"name": "cert-policy-controller-managed-kubeconfig",
+				},
+				"stringData": map[string]interface{}{
+					"kubeconfig": string(hubKubeconfigInternal),
+				},
+			}}
+			_, err = hubClient.Resource(gvrSecret).Namespace(installNamespace).Create(
+				context.TODO(), &secret, metav1.CreateOptions{},
+			)
+			Expect(err).To(BeNil())
+
+			By(logPrefix + "deploying the default cert-policy-controller ManagedClusterAddOn in hosted mode")
+			addon := unstructured.Unstructured{Object: map[string]interface{}{
+				"apiVersion": "addon.open-cluster-management.io/v1alpha1",
+				"kind":       "ManagedClusterAddOn",
+				"metadata": map[string]interface{}{
+					"name": "cert-policy-controller",
+					"annotations": map[string]interface{}{
+						"addon.open-cluster-management.io/hosting-cluster-name": managedClusterList[0].clusterName,
+					},
+				},
+				"spec": map[string]interface{}{
+					"installNamespace": installNamespace,
+				},
+			}}
+			_, err = hubClient.Resource(gvrManagedClusterAddOn).Namespace(cluster.clusterName).Create(
+				context.TODO(), &addon, metav1.CreateOptions{},
+			)
+			Expect(err).To(BeNil())
+
+			verifyCertPolicyDeployment(logPrefix, hubClient, cluster.clusterName, installNamespace, i)
+
+			By(logPrefix +
+				"removing the cert-policy-controller deployment when the ManagedClusterAddOn CR is removed")
+			err = hubClient.Resource(gvrSecret).Namespace(installNamespace).Delete(
+				context.TODO(), secret.GetName(), metav1.DeleteOptions{},
+			)
+			Expect(err).To(BeNil())
+
+			err = clientDynamic.Resource(gvrManagedClusterAddOn).Namespace(cluster.clusterName).Delete(
+				context.TODO(), addon.GetName(), metav1.DeleteOptions{},
+			)
+			Expect(err).To(BeNil())
+
+			deploy := GetWithTimeout(
+				hubClient, gvrDeployment, case4DeploymentName, installNamespace, false, 30,
+			)
+			Expect(deploy).To(BeNil())
+
+			namespace := GetWithTimeout(hubClient, gvrNamespace, installNamespace, "", false, 30)
+			Expect(namespace).To(BeNil())
 		}
 	})
 
@@ -122,7 +223,7 @@ var _ = Describe("Test cert-policy-controller deployment", func() {
 				for _, container := range containerList {
 					containerObj, ok := container.(map[string]interface{})
 					g.Expect(ok).To(BeTrue())
-					if g.Expect(containerObj).To(HaveKey("name")) && containerObj["name"] != case2DeploymentName {
+					if g.Expect(containerObj).To(HaveKey("name")) && containerObj["name"] != case4DeploymentName {
 						continue
 					}
 					if g.Expect(containerObj).To(HaveKey("args")) {


### PR DESCRIPTION
Hosted mode support is needed for the certificate policy controller. This PR adds that support to the grc addon controller.  With this change a user can deploy the certificate controller on a hosting cluster to manage a separate managed cluster.

Refs:
 - https://github.com/stolostron/backlog/issues/26177

Signed-off-by: Gus Parvin <gparvin@redhat.com>