### PR TITLE
Disable leader election when the replicas are set to 1

### DIFF
--- a/pkg/addon/certpolicy/manifests/managedclusterchart/templates/deployment.yaml
+++ b/pkg/addon/certpolicy/manifests/managedclusterchart/templates/deployment.yaml
@@ -42,6 +42,9 @@ spec:
         {{- if .Values.args.defaultDuration }}
         - --default-duration={{ .Values.args.defaultDuration }}
         {{- end }}
+        {{- if eq (.Values.replicas | int) 1 }}
+        - '--leader-elect=false'
+        {{- end }}
         {{- if semverCompare "< 1.14.0" .Capabilities.KubeVersion.Version }}
         - --legacy-leader-elect=true
         {{- end }}

--- a/pkg/addon/iampolicy/manifests/managedclusterchart/templates/deployment.yaml
+++ b/pkg/addon/iampolicy/manifests/managedclusterchart/templates/deployment.yaml
@@ -39,6 +39,9 @@ spec:
         {{- if .Values.args.frequency }}
         - --update-frequency={{ .Values.args.frequency }}
         {{- end }}
+        {{- if eq (.Values.replicas | int) 1 }}
+        - '--leader-elect=false'
+        {{- end }}
         {{- if semverCompare "< 1.14.0" .Capabilities.KubeVersion.Version }}
         - --legacy-leader-elect=true
         {{- end }}

--- a/test/e2e/case3_iam_deployment_test.go
+++ b/test/e2e/case3_iam_deployment_test.go
@@ -233,6 +233,7 @@ var _ = Describe("Test iam-policy-controller deployment", func() {
 						g.Expect(args).To(ContainElement("--log-encoder=console"))
 						g.Expect(args).To(ContainElement("--log-level=8"))
 						g.Expect(args).To(ContainElement("--v=6"))
+						g.Expect(args).To(ContainElement("--leader-elect=false"))
 					}
 				}
 			}, 180, 10).Should(Succeed())

--- a/test/e2e/case4_cert_deployment_test.go
+++ b/test/e2e/case4_cert_deployment_test.go
@@ -231,6 +231,7 @@ var _ = Describe("Test cert-policy-controller deployment", func() {
 						g.Expect(args).To(ContainElement("--log-encoder=console"))
 						g.Expect(args).To(ContainElement("--log-level=8"))
 						g.Expect(args).To(ContainElement("--v=6"))
+						g.Expect(args).To(ContainElement("--leader-elect=false"))
 					}
 				}
 			}, 180, 10).Should(Succeed())


### PR DESCRIPTION
The addons have the deployment strategy of "Recreate", so leader election is not applicable when the replicas are set to 1. In this case, leader election is disabled to reduce resource utilization on the Kubernetes API server.

Relates:
stolostron/backlog#26711
https://issues.redhat.com/browse/ACM-1867

Signed-off-by: mprahl <mprahl@users.noreply.github.com>