### PR TITLE
[release-2.5] Disable leader election when the replicas are set to 1

### DIFF
--- a/pkg/addon/certpolicy/manifests/managedclusterchart/templates/deployment.yaml
+++ b/pkg/addon/certpolicy/manifests/managedclusterchart/templates/deployment.yaml
@@ -41,6 +41,9 @@ spec:
         {{- if .Values.args.defaultDuration }}
         - --default-duration={{ .Values.args.defaultDuration }}
         {{- end }}
+        {{- if eq (.Values.replicas | int) 1 }}
+        - '--leader-elect=false'
+        {{- end }}
         {{- if semverCompare "< 1.14.0" .Capabilities.KubeVersion.Version }}
         - --legacy-leader-elect=true
         {{- end }}

--- a/pkg/addon/configpolicy/manifests/managedclusterchart/templates/deployment.yaml
+++ b/pkg/addon/configpolicy/manifests/managedclusterchart/templates/deployment.yaml
@@ -36,6 +36,9 @@ spec:
         args:
           - "--enable-lease=true"
           - "--cluster-name={{ .Values.clusterName }}"
+          {{- if eq (.Values.replicas | int) 1 }}
+          - '--leader-elect=false'
+          {{- end }}
           {{- if semverCompare "< 1.14.0" .Capabilities.KubeVersion.Version }}
           - --legacy-leader-elect=true
           {{- end }}

--- a/pkg/addon/iampolicy/manifests/managedclusterchart/templates/deployment.yaml
+++ b/pkg/addon/iampolicy/manifests/managedclusterchart/templates/deployment.yaml
@@ -38,6 +38,9 @@ spec:
         {{- if .Values.args.frequency }}
         - --update-frequency={{ .Values.args.frequency }}
         {{- end }}
+        {{- if eq (.Values.replicas | int) 1 }}
+        - '--leader-elect=false'
+        {{- end }}
         {{- if semverCompare "< 1.14.0" .Capabilities.KubeVersion.Version }}
         - --legacy-leader-elect=true
         {{- end }}

--- a/pkg/addon/policyframework/manifests/managedclusterchart/templates/deployment.yaml
+++ b/pkg/addon/policyframework/manifests/managedclusterchart/templates/deployment.yaml
@@ -37,6 +37,9 @@ spec:
         args:
           - '--hub-cluster-configfile=/var/run/klusterlet/kubeconfig'
           - '--health-probe-bind-address=:8081'
+          {{- if eq (.Values.replicas | int) 1 }}
+          - '--leader-elect=false'
+          {{- end }}
           {{- if semverCompare "< 1.14.0" .Capabilities.KubeVersion.Version }}
           - --legacy-leader-elect=true
           {{- end }}
@@ -105,6 +108,9 @@ spec:
         command: ["governance-policy-status-sync"]
         args:
           - '--enable-lease=true'
+          {{- if eq (.Values.replicas | int) 1 }}
+          - '--leader-elect=false'
+          {{- end }}
           - '--hub-cluster-configfile=/var/run/klusterlet/kubeconfig'
           - '--health-probe-bind-address=:8082'
           {{- if semverCompare "< 1.14.0" .Capabilities.KubeVersion.Version }}
@@ -177,6 +183,9 @@ spec:
         imagePullPolicy: "{{ .Values.global.imagePullPolicy }}"
         command: ["governance-policy-template-sync"]
         args:
+          {{- if eq (.Values.replicas | int) 1 }}
+          - '--leader-elect=false'
+          {{- end }}
           {{- if semverCompare "< 1.14.0" .Capabilities.KubeVersion.Version }}
           - --legacy-leader-elect=true
           {{- end }}

--- a/test/e2e/case1_framework_deployment_test.go
+++ b/test/e2e/case1_framework_deployment_test.go
@@ -36,6 +36,7 @@ var _ = Describe("Test framework deployment", func() {
 			Expect(deploy).NotTo(BeNil())
 
 			checkContainersAndAvailability(cluster, i+1)
+			checkArgs(cluster, "--leader-elect=false")
 
 			By(logPrefix + "removing the framework deployment when the ManagedClusterAddOn CR is removed")
 			Kubectl("delete", "-n", cluster.clusterName, "-f", case1ManagedClusterAddOnCR)

--- a/test/e2e/case2_config_deployment_test.go
+++ b/test/e2e/case2_config_deployment_test.go
@@ -133,6 +133,7 @@ var _ = Describe("Test config-policy-controller deployment", func() {
 						g.Expect(args).To(ContainElement("--log-encoder=console"))
 						g.Expect(args).To(ContainElement("--log-level=8"))
 						g.Expect(args).To(ContainElement("--v=6"))
+						g.Expect(args).To(ContainElement("--leader-elect=false"))
 					}
 				}
 			}, 180, 10).Should(Succeed())

--- a/test/e2e/case3_iam_deployment_test.go
+++ b/test/e2e/case3_iam_deployment_test.go
@@ -131,6 +131,7 @@ var _ = Describe("Test iam-policy-controller deployment", func() {
 						g.Expect(args).To(ContainElement("--log-encoder=console"))
 						g.Expect(args).To(ContainElement("--log-level=8"))
 						g.Expect(args).To(ContainElement("--v=6"))
+						g.Expect(args).To(ContainElement("--leader-elect=false"))
 					}
 				}
 			}, 180, 10).Should(Succeed())

--- a/test/e2e/case4_cert_deployment_test.go
+++ b/test/e2e/case4_cert_deployment_test.go
@@ -130,6 +130,7 @@ var _ = Describe("Test cert-policy-controller deployment", func() {
 						g.Expect(args).To(ContainElement("--log-encoder=console"))
 						g.Expect(args).To(ContainElement("--log-level=8"))
 						g.Expect(args).To(ContainElement("--v=6"))
+						g.Expect(args).To(ContainElement("--leader-elect=false"))
 					}
 				}
 			}, 180, 10).Should(Succeed())


### PR DESCRIPTION
This is a backport of https://github.com/stolostron/governance-policy-addon-controller/pull/141.

The addons have the deployment strategy of "Recreate", so leader election is not applicable when the replicas are set to 1. In this case, leader election is disabled to reduce resource utilization on the Kubernetes API server.

Relates:
https://github.com/stolostron/backlog/issues/26711
https://issues.redhat.com/browse/ACM-1867