### PR TITLE
Update IAM CRD

### DIFF
--- a/pkg/addon/iampolicy/manifests/managedclusterchart/templates/policy.open-cluster-management.io_iampolicy_crd.yaml
+++ b/pkg/addon/iampolicy/manifests/managedclusterchart/templates/policy.open-cluster-management.io_iampolicy_crd.yaml
@@ -1,6 +1,8 @@
 # Copyright Contributors to the Open Cluster Management project
 
 {{- if semverCompare "< 1.16.0" .Capabilities.KubeVersion.Version }}
+
+---
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
@@ -117,6 +119,8 @@ status:
   conditions: []
   storedVersions: []
 {{ else }}
+
+---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:


### PR DESCRIPTION
- Add  newlines from `yq` update

Peer with:
- https://github.com/open-cluster-management-io/governance-policy-addon-controller/pull/51

The curious thing here is that Cert doesn't get the same update because it passes its manifests through Kustomize for some additional customizations, which removes the newlines 🤔 :
https://github.com/stolostron/cert-policy-controller/blob/78c9b25eed6348264b81f16d952bf018783b45cb/Makefile#L152-L154