### PR TITLE
Fix the CRD read permissions on hosted config-policy-controllers

### DIFF
--- a/pkg/addon/configpolicy/manifests/managedclusterchart/templates/cluster_role.yaml
+++ b/pkg/addon/configpolicy/manifests/managedclusterchart/templates/cluster_role.yaml
@@ -7,7 +7,6 @@ kind: Role
 kind: ClusterRole
 {{- end }}
 metadata:
-  creationTimestamp: null
   name: {{ include "controller.rolename" . }}
   {{- if eq .Values.installMode "Hosted" }}
   namespace: {{ .Release.Namespace }}
@@ -74,16 +73,6 @@ rules:
   - policy-encryption-key
   resources:
   - secrets
-  verbs:
-  - get
-  - list
-  - watch
-- apiGroups:
-  - apiextensions.k8s.io
-  resources:
-  - customresourcedefinitions
-  resourceNames:
-  - configurationpolicies.policy.open-cluster-management.io
   verbs:
   - get
   - list

--- a/pkg/addon/configpolicy/manifests/managedclusterchart/templates/cluster_role_binding_crd_reader.yaml
+++ b/pkg/addon/configpolicy/manifests/managedclusterchart/templates/cluster_role_binding_crd_reader.yaml
@@ -1,16 +1,11 @@
 # Copyright Contributors to the Open Cluster Management project
 
-apiVersion: rbac.authorization.k8s.io/v1
 {{- if eq .Values.installMode "Hosted" }}
-kind: RoleBinding
-{{- else }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
-{{- end }}
 metadata:
-  name: {{ include "controller.rolename" . }}
-  {{- if eq .Values.installMode "Hosted" }}
-  namespace: {{ .Release.Namespace }}
-  {{- end }}
+  name: ocm:{{ .Release.Namespace }}:{{ include "controller.fullname" . }}
   labels:
     app: {{ include "controller.fullname" . }}
     chart: {{ include "controller.chart" . }}
@@ -19,13 +14,10 @@ metadata:
     addon.open-cluster-management.io/hosted-manifest-location: hosting
 roleRef:
   apiGroup: rbac.authorization.k8s.io
-  {{- if eq .Values.installMode "Hosted" }}
-  kind: Role
-  {{- else }}
   kind: ClusterRole
-  {{- end }}
-  name: {{ include "controller.rolename" . }}
+  name: ocm:{{ include "controller.fullname" . }}
 subjects:
 - kind: ServiceAccount
   name: {{ include "controller.serviceAccountName" . }}
   namespace: {{ .Release.Namespace }}
+{{- end }}

--- a/pkg/addon/configpolicy/manifests/managedclusterchart/templates/cluster_role_crd_reader.yaml
+++ b/pkg/addon/configpolicy/manifests/managedclusterchart/templates/cluster_role_crd_reader.yaml
@@ -1,0 +1,26 @@
+# Copyright Contributors to the Open Cluster Management project
+
+{{- if eq .Values.installMode "Hosted" }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: ocm:{{ include "controller.fullname" . }}
+  labels:
+    app: {{ include "controller.fullname" . }}
+    chart: {{ include "controller.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+    addon.open-cluster-management.io/hosted-manifest-location: hosting
+rules:
+- apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  resourceNames:
+  - configurationpolicies.policy.open-cluster-management.io
+  verbs:
+  - get
+  - list
+  - watch
+{{- end }}


### PR DESCRIPTION
This accidentally used a Role instead of a ClusterRole. The ClusterRole will be the same for all hosted clusters but the ClusterRoleBinding is unique per hosted cluster since there's no way for ManifestWork to merge the subjects array.

Relates:
https://issues.redhat.com/browse/ACM-2923

Signed-off-by: mprahl <mprahl@users.noreply.github.com>
(cherry picked from commit 1eb607e3f1bb81e99fedf5bd9a8dcede3d572df4)