### PR TITLE
Revert "Backport the spec.copyPolicyMetadata field for 2.6"

### DIFF
--- a/pkg/addon/policyframework/manifests/managedclusterchart/templates/policy.open-cluster-management.io_policies_crd.yaml
+++ b/pkg/addon/policyframework/manifests/managedclusterchart/templates/policy.open-cluster-management.io_policies_crd.yaml
@@ -47,9 +47,6 @@ spec:
         spec:
           description: PolicySpec defines the desired state of Policy
           properties:
-            copyPolicyMetadata:
-              description: If set to true (default), all the policy's labels and annotations will be copied to the replicated policy. If set to false, only the policy framework specific policy labels and annotations will be copied to the replicated policy.
-              type: boolean
             disabled:
               type: boolean
             policy-templates:
@@ -209,9 +206,6 @@ spec:
             spec:
               description: PolicySpec defines the desired state of Policy
               properties:
-                copyPolicyMetadata:
-                  description: If set to true (default), all the policy's labels and annotations will be copied to the replicated policy. If set to false, only the policy framework specific policy labels and annotations will be copied to the replicated policy.
-                  type: boolean
                 disabled:
                   type: boolean
                 policy-templates:


### PR DESCRIPTION
This reverts commit 6b073256e8a94a595364ead0170e017ee79f7110. This was a temporary commit for a hotfix build.