### PR TITLE
Manual cherry-pick of #65 (Use org/branch fallbacks for sync script)

### DIFF
--- a/build/crd-sync.sh
+++ b/build/crd-sync.sh
@@ -2,14 +2,17 @@
 
 set -euxo pipefail  # exit on errors and unset vars, and stop on the first error in a "pipeline"
 
-BRANCH="${BRANCH:-main}"
+ORG=${ORG:-"stolostron"}
+BRANCH=${BRANCH:-"main"}
 
 mkdir -p .go
 
 # Clone repositories containing the CRD definitions
 for REPO in cert-policy-controller config-policy-controller iam-policy-controller governance-policy-propagator
 do
-    git clone -b "${BRANCH}" --depth 1 https://github.com/stolostron/${REPO}.git .go/${REPO}
+    # Try a given ORG/BRANCH, but fall back to the stolostron org on the main branch if it fails
+    git clone -b "${BRANCH}" --depth 1 https://github.com/${ORG}/${REPO}.git .go/${REPO} \
+    || git clone -b main --depth 1 https://github.com/stolostron/${REPO}.git .go/${REPO}
 done
 
 (


### PR DESCRIPTION
Manual cherry-pick of:
- open-cluster-management-io/governance-policy-addon-controller#65

This allows proactive PRs by specifying something like:
```bash
ORG=gh-user BRANCH=my-changes ./build/crd-sync.sh
```

(cherry picked from commit 55067ca7512e7ce97e20e800bd969a495034936c)

Closes #177 