### PR TITLE
[release-2.7] Use a unique ClusterRoleBinding name to account for hosted mode

### DIFF
--- a/pkg/addon/policyframework/manifests/managedclusterchart/templates/cluster_role_binding_crd_listwatch.yaml
+++ b/pkg/addon/policyframework/manifests/managedclusterchart/templates/cluster_role_binding_crd_listwatch.yaml
@@ -3,7 +3,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: {{ include "controller.rolename" . }}-crd-binding
+  name: ocm:{{ .Release.Namespace }}:{{ include "controller.fullname" . }}
   labels:
     app: {{ include "controller.fullname" . }}
     chart: {{ include "controller.chart" . }}


### PR DESCRIPTION
Prior to this, the governance-policy-framework ClusterRoleBinding would have the same name for every hosted cluster on the hosting/management cluster. The generated ManifestWork objects would overwrite each other since it did not append to the subjects array. Using a unique name per hosted cluster like the config-policy-controller does will resolve this.

Relates:
https://issues.redhat.com/browse/ACM-4486

Signed-off-by: mprahl <mprahl@users.noreply.github.com>
(cherry picked from commit cce56fadef78a48b33524d1c99888de59c7ec7d7)