### PR TITLE
Update release regex

### DIFF
--- a/.github/workflows/kind.yml
+++ b/.github/workflows/kind.yml
@@ -4,11 +4,11 @@ on:
   push:
     branches:
       - main
-      - release-2.[6-9]
+      - release-[0-9]+.[0-9]+
   pull_request:
     branches:
       - main
-      - release-2.[6-9]
+      - release-[0-9]+.[0-9]+
 
 defaults:
   run:

--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -4,11 +4,11 @@ on:
   push:
     branches:
       - main
-      - release-2.[6-9]
+      - release-[0-9]+.[0-9]+
   pull_request:
     branches:
       - main
-      - release-2.[6-9]
+      - release-[0-9]+.[0-9]+
 
 defaults:
   run:

--- a/.github/workflows/upstream.yml
+++ b/.github/workflows/upstream.yml
@@ -4,7 +4,7 @@ on:
   pull_request:
     branches:
       - main
-      - release-2.[5-9]
+      - release-[0-9]+.[0-9]+
 
 defaults:
   run:


### PR DESCRIPTION
This was originally capped since we didn't want to run workflows against `2.2`, but now we don't want to cap it at `2.9`.