### PR TITLE
Remove ConfigMap permissions (IAM/Cert)

### DIFF
--- a/pkg/addon/certpolicy/manifests/managedclusterchart/templates/leader_election_role.yaml
+++ b/pkg/addon/certpolicy/manifests/managedclusterchart/templates/leader_election_role.yaml
@@ -14,18 +14,6 @@ metadata:
     addon.open-cluster-management.io/hosted-manifest-location: hosting
 rules:
 - apiGroups:
-  - ""
-  resources:
-  - configmaps
-  verbs:
-  - get
-  - list
-  - watch
-  - create
-  - update
-  - patch
-  - delete
-- apiGroups:
   - coordination.k8s.io
   resources:
   - leases

--- a/pkg/addon/iampolicy/manifests/managedclusterchart/templates/leader_election_role.yaml
+++ b/pkg/addon/iampolicy/manifests/managedclusterchart/templates/leader_election_role.yaml
@@ -14,18 +14,6 @@ metadata:
     addon.open-cluster-management.io/hosted-manifest-location: hosting    
 rules:
 - apiGroups:
-  - ""
-  resources:
-  - configmaps
-  verbs:
-  - get
-  - list
-  - watch
-  - create
-  - update
-  - patch
-  - delete
-- apiGroups:
   - coordination.k8s.io
   resources:
   - leases


### PR DESCRIPTION
ConfigMap permissions were only necessary for legacy leader election, which was removed.

ref: https://issues.redhat.com/browse/ACM-5042