### PR TITLE
Bug: delete all policies when management + hub hosted mode

### DIFF
--- a/.tekton/governance-policy-addon-controller-ocyz-pull-request.yaml
+++ b/.tekton/governance-policy-addon-controller-ocyz-pull-request.yaml
@@ -15,7 +15,7 @@ metadata:
     appstudio.openshift.io/component: governance-policy-addon-controller-ocyz
     pipelines.appstudio.openshift.io/type: build
   name: governance-policy-addon-controller-ocyz-on-pull-request
-  namespace: crt-redhat-acm-tenant
+  namespace: red-hat-acm-tenant
 spec:
   params:
   - name: dockerfile
@@ -25,7 +25,7 @@ spec:
   - name: image-expires-after
     value: 5d
   - name: output-image
-    value: quay.io/redhat-user-workloads/crt-redhat-acm-tenant/governance-policy-addon-controller/governance-policy-addon-controller-ocyz:on-pr-{{revision}}
+    value: quay.io/redhat-user-workloads/red-hat-acm-tenant/governance-policy-addon-controller/governance-policy-addon-controller-ocyz:on-pr-{{revision}}
   - name: path-context
     value: .
   - name: revision

--- a/.tekton/governance-policy-addon-controller-ocyz-push.yaml
+++ b/.tekton/governance-policy-addon-controller-ocyz-push.yaml
@@ -14,7 +14,7 @@ metadata:
     appstudio.openshift.io/component: governance-policy-addon-controller-ocyz
     pipelines.appstudio.openshift.io/type: build
   name: governance-policy-addon-controller-ocyz-on-push
-  namespace: crt-redhat-acm-tenant
+  namespace: red-hat-acm-tenant
 spec:
   params:
   - name: dockerfile
@@ -22,7 +22,7 @@ spec:
   - name: git-url
     value: '{{repo_url}}'
   - name: output-image
-    value: quay.io/redhat-user-workloads/crt-redhat-acm-tenant/governance-policy-addon-controller/governance-policy-addon-controller-ocyz:{{revision}}
+    value: quay.io/redhat-user-workloads/red-hat-acm-tenant/governance-policy-addon-controller/governance-policy-addon-controller-ocyz:{{revision}}
   - name: path-context
     value: .
   - name: revision

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -48,6 +48,8 @@ spec:
           value: registry.redhat.io/openshift4/ose-kube-rbac-proxy:v4.10
         - name: GOVERNANCE_POLICY_FRAMEWORK_ADDON_IMAGE
           value: quay.io/stolostron/governance-policy-framework-addon:latest
+        - name: HOSTING_CLUSTER_NAME
+          value: cluster1
         name: manager
         securityContext:
           allowPrivilegeEscalation: false

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -77,6 +77,15 @@ rules:
   - patch
   - update
 - apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - get
+  - list
+  - patch
+  - update
+- apiGroups:
   - authorization.k8s.io
   resources:
   - subjectaccessreviews

--- a/main.go
+++ b/main.go
@@ -76,6 +76,8 @@ import (
 //+kubebuilder:rbac:groups=core,resources=pods,verbs=get;list;watch
 //+kubebuilder:rbac:groups=config.openshift.io,resources=infrastructures,verbs=get;list;watch
 
+//+kubebuilder:rbac:groups=apiextensions.k8s.io,resources=customresourcedefinitions,verbs=get;patch;update;list
+
 var (
 	setupLog    = ctrl.Log.WithName("setup")
 	ctrlVersion = version.Info{}

--- a/test/e2e/e2e_suite_test.go
+++ b/test/e2e/e2e_suite_test.go
@@ -41,6 +41,7 @@ var (
 	gvrSecret              schema.GroupVersionResource
 	gvrServiceMonitor      schema.GroupVersionResource
 	gvrService             schema.GroupVersionResource
+	gvrPolicyCrd           schema.GroupVersionResource
 	managedClusterList     []managedClusterConfig
 	clientDynamic          dynamic.Interface
 	hubKubeconfigInternal  []byte
@@ -77,6 +78,11 @@ var _ = BeforeSuite(func() {
 		Group: "monitoring.coreos.com", Version: "v1", Resource: "servicemonitors",
 	}
 	gvrService = schema.GroupVersionResource{Group: "", Version: "v1", Resource: "services"}
+	gvrPolicyCrd = schema.GroupVersionResource{
+		Group:    "apiextensions.k8s.io",
+		Version:  "v1",
+		Resource: "customresourcedefinitions",
+	}
 	clientDynamic = NewKubeClientDynamic("", kubeconfigFilename+"1.kubeconfig", "")
 
 	var err error


### PR DESCRIPTION
description: When hcp clusters are created on the MCV2, policies are rolled out well.
When deleting the hcp cluster, we see that all the ACM policies on the ACM hub are also deleted.

solution: add  delete-orphan annotation into the policy crd
ref: https://issues.redhat.com/browse/ACM-6604