### PR TITLE
[release-2.8]Ensure policies remain when hosting cluster is a hub 

### DIFF
--- a/pkg/addon/policyframework/agent_addon.go
+++ b/pkg/addon/policyframework/agent_addon.go
@@ -74,8 +74,11 @@ func getValues(cluster *clusterv1.ManagedCluster,
 			PkgLogLevel: -1,
 		},
 	}
+
+	annotations := addon.GetAnnotations()
+	hostingClusterName := annotations[addonapiv1alpha1.HostingClusterNameAnnotationKey]
 	// special case for local-cluster
-	if cluster.Name == "local-cluster" {
+	if cluster.Name == "local-cluster" || hostingClusterName == "local-cluster" {
 		userValues.OnMulticlusterHub = true
 	}
 
@@ -86,8 +89,6 @@ func getValues(cluster *clusterv1.ManagedCluster,
 			break
 		}
 	}
-
-	annotations := addon.GetAnnotations()
 
 	if val, ok := annotations["addon.open-cluster-management.io/on-multicluster-hub"]; ok {
 		if strings.EqualFold(val, "true") {

--- a/pkg/addon/policyframework/manifests/managedclusterchart/templates/cleanup_pod.yaml
+++ b/pkg/addon/policyframework/manifests/managedclusterchart/templates/cleanup_pod.yaml
@@ -1,5 +1,6 @@
 # Copyright Contributors to the Open Cluster Management project
 
+{{- if or (not .Values.onMulticlusterHub) (eq .Values.installMode "Hosted") }}
 apiVersion: v1
 kind: Pod
 metadata:
@@ -65,3 +66,4 @@ spec:
   serviceAccount: {{ include "controller.serviceAccountName" . }}
   securityContext:
     runAsNonRoot: true
+{{- end }}

--- a/pkg/addon/policyframework/manifests/managedclusterchart/templates/deployment.yaml
+++ b/pkg/addon/policyframework/manifests/managedclusterchart/templates/deployment.yaml
@@ -74,7 +74,7 @@ spec:
           - --log-encoder={{ .Values.args.logEncoder }}
           - --log-level={{ .Values.args.logLevel }}
           - --v={{ .Values.args.pkgLogLevel }}
-          {{- if .Values.onMulticlusterHub }}
+          {{- if and (.Values.onMulticlusterHub) (ne .Values.installMode "Hosted") }}
           - --disable-spec-sync=true
           {{- end }}
           {{- if eq .Values.installMode "Hosted" }}

--- a/test/e2e/case2_config_deployment_test.go
+++ b/test/e2e/case2_config_deployment_test.go
@@ -22,6 +22,8 @@ const (
 	case2DeploymentName           string = "config-policy-controller"
 	case2PodSelector              string = "app=config-policy-controller"
 	case2OpenShiftClusterClaim    string = "../resources/openshift_cluster_claim.yaml"
+	policyCrdName                 string = "policies.policy.open-cluster-management.io"
+	deletionOrphanAnnotationKey   string = "addon.open-cluster-management.io/deletion-orphan"
 )
 
 func verifyConfigPolicyDeployment(
@@ -175,7 +177,7 @@ var _ = Describe("Test config-policy-controller deployment", func() {
 
 			installAddonInHostedMode(
 				logPrefix, hubClient, case2ManagedClusterAddOnName,
-				cluster.clusterName, hubClusterConfig.clusterName, installNamespace)
+				cluster.clusterName, hubClusterConfig.clusterName, installNamespace, nil)
 
 			// Use i+1 since the for loop ranges over a slice skipping first index
 			verifyConfigPolicyDeployment(logPrefix, hubClient, cluster.clusterName, installNamespace, i+1)
@@ -227,7 +229,7 @@ var _ = Describe("Test config-policy-controller deployment", func() {
 
 				installAddonInHostedMode(
 					logPrefix, hubClient, case2ManagedClusterAddOnName,
-					cluster.clusterName, hubClusterConfig.clusterName, installNamespace)
+					cluster.clusterName, hubClusterConfig.clusterName, installNamespace, nil)
 
 				// Use i+1 since the for loop ranges over a slice skipping first index
 				verifyConfigPolicyDeployment(logPrefix, hubClient, cluster.clusterName, installNamespace, i+1)

--- a/test/e2e/case3_iam_deployment_test.go
+++ b/test/e2e/case3_iam_deployment_test.go
@@ -170,7 +170,7 @@ var _ = Describe("Test iam-policy-controller deployment", func() {
 
 			installAddonInHostedMode(
 				logPrefix, hubClient, case3ManagedClusterAddOnName,
-				cluster.clusterName, hubClusterConfig.clusterName, installNamespace)
+				cluster.clusterName, hubClusterConfig.clusterName, installNamespace, nil)
 
 			// Use i+1 since the for loop ranges over a slice skipping first index
 			verifyIamPolicyDeployment(logPrefix, hubClient, cluster.clusterName, installNamespace, i+1)
@@ -224,7 +224,7 @@ var _ = Describe("Test iam-policy-controller deployment", func() {
 
 				installAddonInHostedMode(
 					logPrefix, hubClient, case3ManagedClusterAddOnName,
-					cluster.clusterName, hubClusterConfig.clusterName, installNamespace)
+					cluster.clusterName, hubClusterConfig.clusterName, installNamespace, nil)
 
 				// Use i+1 since the for loop ranges over a slice skipping first index
 				verifyIamPolicyDeployment(logPrefix, hubClient, cluster.clusterName, installNamespace, i+1)

--- a/test/e2e/case4_cert_deployment_test.go
+++ b/test/e2e/case4_cert_deployment_test.go
@@ -169,7 +169,7 @@ var _ = Describe("Test cert-policy-controller deployment", func() {
 
 			installAddonInHostedMode(
 				logPrefix, hubClient, case4ManagedClusterAddOnName,
-				cluster.clusterName, hubClusterConfig.clusterName, installNamespace)
+				cluster.clusterName, hubClusterConfig.clusterName, installNamespace, nil)
 
 			// Use i+1 since the for loop ranges over a slice skipping first index
 			verifyCertPolicyDeployment(logPrefix, hubClient, cluster.clusterName, installNamespace, i+1)
@@ -223,7 +223,7 @@ var _ = Describe("Test cert-policy-controller deployment", func() {
 
 				installAddonInHostedMode(
 					logPrefix, hubClient, case4ManagedClusterAddOnName,
-					cluster.clusterName, hubClusterConfig.clusterName, installNamespace)
+					cluster.clusterName, hubClusterConfig.clusterName, installNamespace, nil)
 
 				// Use i+1 since the for loop ranges over a slice skipping first index
 				verifyCertPolicyDeployment(logPrefix, hubClient, cluster.clusterName, installNamespace, i+1)

--- a/test/e2e/e2e_suite_test.go
+++ b/test/e2e/e2e_suite_test.go
@@ -41,6 +41,7 @@ var (
 	gvrSecret              schema.GroupVersionResource
 	gvrServiceMonitor      schema.GroupVersionResource
 	gvrService             schema.GroupVersionResource
+	gvrPolicyCrd           schema.GroupVersionResource
 	managedClusterList     []managedClusterConfig
 	clientDynamic          dynamic.Interface
 	hubKubeconfigInternal  []byte
@@ -77,6 +78,11 @@ var _ = BeforeSuite(func() {
 		Group: "monitoring.coreos.com", Version: "v1", Resource: "servicemonitors",
 	}
 	gvrService = schema.GroupVersionResource{Group: "", Version: "v1", Resource: "services"}
+	gvrPolicyCrd = schema.GroupVersionResource{
+		Group:    "apiextensions.k8s.io",
+		Version:  "v1",
+		Resource: "customresourcedefinitions",
+	}
 	clientDynamic = NewKubeClientDynamic("", kubeconfigFilename+"1.kubeconfig", "")
 
 	var err error


### PR DESCRIPTION
The bug was by deleting the hcp cluster, we see that all the ACM policies on the ACM hub are also deleted.

Signed-off-by: Yi Rae Kim <yikim@redhat.com>
(cherry picked from commit c89a259ee16d48951964fe4e26242f0cc543188c)