### PR TITLE
[Manual Sync release-2.7] Create the cluster namespace when a hub is imported by a global hub

### DIFF
--- a/pkg/addon/policyframework/manifests/managedclusterchart/templates/namespace.yaml
+++ b/pkg/addon/policyframework/manifests/managedclusterchart/templates/namespace.yaml
@@ -1,6 +1,6 @@
 # Copyright Contributors to the Open Cluster Management project
 
-{{- if and (not .Values.onMulticlusterHub) (ne .Values.installMode "Hosted") }}
+{{- if or (and (not .Values.onMulticlusterHub) (ne .Values.installMode "Hosted")) (and .Values.onMulticlusterHub .Values.args.syncPoliciesOnMulticlusterHub) }}
 apiVersion: v1
 kind: Namespace
 metadata:


### PR DESCRIPTION
When syncPoliciesOnMulticlusterHub is true, it's indicating that the hub is imported by a global hub. The namespace must be created on the hub to sync policies from the global hub. The namespace also needs to be cleaned up when uninstalled, so the clean up pod is now enabled in this scenario too.

Relates:
https://issues.redhat.com/browse/ACM-7655

Signed-off-by: mprahl <mprahl@users.noreply.github.com>
(cherry picked from commit 21c01f09f46b48d119036da819a0af0a3278a52c)