### PR TITLE
Use the correct kubeconfig for hosted mode tests

### DIFF
--- a/test/e2e/case3_iam_deployment_test.go
+++ b/test/e2e/case3_iam_deployment_test.go
@@ -212,6 +212,7 @@ var _ = Describe("Test iam-policy-controller deployment", func() {
 					clusterName:   cluster.clusterName,
 					clusterType:   cluster.clusterType,
 					hostedOnHub:   true,
+					kubeconfig:    cluster.kubeconfig,
 				}
 				hubClusterConfig := managedClusterList[0]
 				hubClient := hubClusterConfig.clusterClient
@@ -220,7 +221,7 @@ var _ = Describe("Test iam-policy-controller deployment", func() {
 
 				setupClusterSecretForHostedMode(
 					logPrefix, hubClient, "external-managed-kubeconfig",
-					string(hubKubeconfigInternal), installNamespace)
+					string(cluster.kubeconfig), installNamespace)
 
 				installAddonInHostedMode(
 					logPrefix, hubClient, case3ManagedClusterAddOnName,

--- a/test/e2e/case4_cert_deployment_test.go
+++ b/test/e2e/case4_cert_deployment_test.go
@@ -157,6 +157,7 @@ var _ = Describe("Test cert-policy-controller deployment", func() {
 				clusterName:   cluster.clusterName,
 				clusterType:   cluster.clusterType,
 				hostedOnHub:   true,
+				kubeconfig:    cluster.kubeconfig,
 			}
 			hubClusterConfig := managedClusterList[0]
 			hubClient := hubClusterConfig.clusterClient
@@ -165,7 +166,7 @@ var _ = Describe("Test cert-policy-controller deployment", func() {
 
 			setupClusterSecretForHostedMode(
 				logPrefix, hubClient, "cert-policy-controller-managed-kubeconfig",
-				string(hubKubeconfigInternal), installNamespace)
+				string(cluster.kubeconfig), installNamespace)
 
 			installAddonInHostedMode(
 				logPrefix, hubClient, case4ManagedClusterAddOnName,


### PR DESCRIPTION
This is a follow up to the following commit to account for the IAM and Cert deployments:
10a1e44358567857ff1ae65e2b97e277ed346e5e