### PR TITLE
Add missing clustermanagementaddons/status patch permissions

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -33,6 +33,18 @@ rules:
   - update
 - apiGroups:
   - addon.open-cluster-management.io
+  resourceNames:
+  - cert-policy-controller
+  - config-policy-controller
+  - governance-policy-framework
+  - iam-policy-controller
+  resources:
+  - clustermanagementaddons/status
+  verbs:
+  - patch
+  - update
+- apiGroups:
+  - addon.open-cluster-management.io
   resources:
   - managedclusteraddons
   verbs:

--- a/main.go
+++ b/main.go
@@ -74,6 +74,7 @@ import (
 //+kubebuilder:rbac:groups=addon.open-cluster-management.io,resources=managedclusteraddons,verbs=delete,resourceNames=config-policy-controller;governance-policy-framework;iam-policy-controller;cert-policy-controller
 //+kubebuilder:rbac:groups=addon.open-cluster-management.io,resources=managedclusteraddons/finalizers,verbs=update,resourceNames=config-policy-controller;governance-policy-framework;iam-policy-controller;cert-policy-controller
 //+kubebuilder:rbac:groups=addon.open-cluster-management.io,resources=managedclusteraddons/status,verbs=update;patch,resourceNames=config-policy-controller;governance-policy-framework;iam-policy-controller;cert-policy-controller
+//+kubebuilder:rbac:groups=addon.open-cluster-management.io,resources=clustermanagementaddons/status,verbs=update;patch,resourceNames=config-policy-controller;governance-policy-framework;iam-policy-controller;cert-policy-controller
 
 //+kubebuilder:rbac:groups=addon.open-cluster-management.io,resources=clustermanagementaddons/finalizers,verbs=update,resourceNames=config-policy-controller;governance-policy-framework;iam-policy-controller;cert-policy-controller
 //+kubebuilder:rbac:groups=addon.open-cluster-management.io,resources=addondeploymentconfigs,verbs=get;list;watch


### PR DESCRIPTION
This will remove the log errors of:
controller failed to sync "governance-policy-framework", err: clustermanagementaddons.addon.open-cluster-management.io "governance-policy-framework" is forbidden: User "system:serviceaccount:open-cluster-management:grc-policy-addon-sa" cannot patch resource "clustermanagementaddons/status" in API group "addon.open-cluster-management.io" at the cluster scope