### PR TITLE
[release-2.9] Build from stolostron ocm

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -174,9 +174,10 @@ kind-delete-cluster: ## Delete a kind cluster.
 	-rm $(KIND_KUBECONFIG_INTERNAL)
 
 OCM_REPO = $(PWD)/.go/ocm
+OCM_BRANCH = backplane-2.4
 $(OCM_REPO):
 	@mkdir -p .go
-	git clone --depth 1 https://github.com/open-cluster-management-io/ocm.git .go/ocm
+	git clone --depth 1 https://github.com/stolostron/ocm.git .go/ocm --branch $(OCM_BRANCH)
 
 .PHONY: kind-deploy-registration-operator-hub
 kind-deploy-registration-operator-hub: $(OCM_REPO) $(KIND_KUBECONFIG) ## Deploy the ocm registration operator to the kind cluster.


### PR DESCRIPTION
Sets the OCM clone to the equivalent MCE `backplane-2.4` branch.

ref: https://issues.redhat.com/browse/ACM-10392