### PR TITLE
[release-2.9] Use `OCM_REGISTRY`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -175,13 +175,14 @@ kind-delete-cluster: ## Delete a kind cluster.
 
 OCM_REPO = $(PWD)/.go/ocm
 OCM_BRANCH = backplane-2.4
+OCM_REGISTRY = quay.io/stolostron
 $(OCM_REPO):
 	@mkdir -p .go
 	git clone --depth 1 https://github.com/stolostron/ocm.git .go/ocm --branch $(OCM_BRANCH)
 
 .PHONY: kind-deploy-registration-operator-hub
 kind-deploy-registration-operator-hub: $(OCM_REPO) $(KIND_KUBECONFIG) ## Deploy the ocm registration operator to the kind cluster.
-	cd $(OCM_REPO) && KUBECONFIG=$(KIND_KUBECONFIG) KUSTOMIZE_VERSION=$(KUSTOMIZE_VERSION) IMAGE_TAG=$(OCM_BRANCH) IMAGE_REGISTRY=$(REGISTRY) make deploy-hub
+	cd $(OCM_REPO) && KUBECONFIG=$(KIND_KUBECONFIG) KUSTOMIZE_VERSION=$(KUSTOMIZE_VERSION) IMAGE_TAG=$(OCM_BRANCH) IMAGE_REGISTRY=$(OCM_REGISTRY) make deploy-hub
 	@printf "\n*** Pausing and waiting to let everything deploy ***\n\n"
 	KUBECONFIG=$(KIND_KUBECONFIG) $(KUBEWAIT) -r deploy/cluster-manager -n open-cluster-management -c condition=Available -m 90
 	KUBECONFIG=$(KIND_KUBECONFIG) $(KUBEWAIT) -r deploy/cluster-manager-placement-controller -n open-cluster-management-hub -c condition=Available -m 90
@@ -192,17 +193,17 @@ kind-deploy-registration-operator-hub: $(OCM_REPO) $(KIND_KUBECONFIG) ## Deploy 
 kind-deploy-registration-operator-managed: $(OCM_REPO) $(KIND_KUBECONFIG) ## Deploy the ocm registration operator to the kind cluster.
 	cd $(OCM_REPO) && \
 	KUBECONFIG=$(KIND_KUBECONFIG) MANAGED_CLUSTER_NAME=$(CLUSTER_NAME) HUB_KUBECONFIG=$(HUB_KUBECONFIG_INTERNAL) \
-	KUSTOMIZE_VERSION=$(KUSTOMIZE_VERSION) IMAGE_TAG=$(OCM_BRANCH) IMAGE_REGISTRY=$(REGISTRY) make deploy-spoke-operator
+	KUSTOMIZE_VERSION=$(KUSTOMIZE_VERSION) IMAGE_TAG=$(OCM_BRANCH) IMAGE_REGISTRY=$(OCM_REGISTRY) make deploy-spoke-operator
 	cd $(OCM_REPO) && \
 	KUBECONFIG=$(KIND_KUBECONFIG) MANAGED_CLUSTER_NAME=$(CLUSTER_NAME) HUB_KUBECONFIG=$(HUB_KUBECONFIG_INTERNAL) \
-	KUSTOMIZE_VERSION=$(KUSTOMIZE_VERSION) IMAGE_TAG=$(OCM_BRANCH) IMAGE_REGISTRY=$(REGISTRY) make apply-spoke-cr
+	KUSTOMIZE_VERSION=$(KUSTOMIZE_VERSION) IMAGE_TAG=$(OCM_BRANCH) IMAGE_REGISTRY=$(OCM_REGISTRY) make apply-spoke-cr
 
 .PHONY: kind-deploy-registration-operator-managed-hosted
 kind-deploy-registration-operator-managed-hosted: $(OCM_REPO) $(KIND_KUBECONFIG) ## Deploy the ocm registration operator to the kind cluster in hosted mode.
 	cd $(OCM_REPO) && \
 	KUBECONFIG=$(HUB_KUBECONFIG) MANAGED_CLUSTER_NAME=$(CLUSTER_NAME) HUB_KUBECONFIG=$(HUB_KUBECONFIG_INTERNAL) \
 	HOSTED_CLUSTER_MANAGER_NAME=$(HUB_CLUSTER_NAME) EXTERNAL_MANAGED_KUBECONFIG=$(KIND_KUBECONFIG_INTERNAL) \
-	KUSTOMIZE_VERSION=$(KUSTOMIZE_VERSION) IMAGE_TAG=$(OCM_BRANCH) IMAGE_REGISTRY=$(REGISTRY) make deploy-spoke-hosted
+	KUSTOMIZE_VERSION=$(KUSTOMIZE_VERSION) IMAGE_TAG=$(OCM_BRANCH) IMAGE_REGISTRY=$(OCM_REGISTRY) make deploy-spoke-hosted
 
 .PHONY: kind-approve-cluster
 kind-approve-cluster: $(KIND_KUBECONFIG) ## Approve managed cluster in the kind cluster.


### PR DESCRIPTION
`REGISTRY` is too generic and is being unintentionally overridden in the framework tests.

Manual cherry-pick of:
- #471 