### PR TITLE
Add the missing subresources section for the v1beta1 CRD (CertificatePolicy)

### DIFF
--- a/pkg/addon/certpolicy/manifests/managedclusterchart/templates/policy.open-cluster-management.io_certificatepolicy_crd.yaml
+++ b/pkg/addon/certpolicy/manifests/managedclusterchart/templates/policy.open-cluster-management.io_certificatepolicy_crd.yaml
@@ -19,6 +19,8 @@ spec:
     plural: certificatepolicies
     singular: certificatepolicy
   scope: Namespaced
+  subresources:
+    status: {}
   validation:
     openAPIV3Schema:
       description: |-


### PR DESCRIPTION
This takes care of the CertificatePolicy one which wasn't in the sync from upstream PR.

Relates:
https://issues.redhat.com/browse/ACM-11498