### PR TITLE
Re-Sync from open-cluster-management-io/governance-policy-addon-controller: #173

### DIFF
--- a/pkg/addon/policyframework/agent_addon.go
+++ b/pkg/addon/policyframework/agent_addon.go
@@ -104,7 +104,10 @@ func getValues(cluster *clusterv1.ManagedCluster,
 	annotations := addon.GetAnnotations()
 	hostingClusterName := annotations[addonapiv1alpha1.HostingClusterNameAnnotationKey]
 	// special case for local-cluster
-	if cluster.Name == "local-cluster" || hostingClusterName == "local-cluster" {
+	isLocal := cluster.Name == "local-cluster" ||
+		hostingClusterName == "local-cluster" ||
+		cluster.GetLabels()["local-cluster"] == "true"
+	if isLocal {
 		userValues.OnMulticlusterHub = true
 	}
 


### PR DESCRIPTION
Syncing the following PRs:
* open-cluster-management-io/governance-policy-addon-controller#173

The original PR didn't play well with some changing Konflux configurations.

Closes https://github.com/stolostron/governance-policy-addon-controller/issues/642