### PR TITLE
Add standalone-hub-templating addon

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -282,8 +282,9 @@ e2e-run-instrumented: e2e-build-instrumented
 
 .PHONY: e2e-stop-instrumented
 e2e-stop-instrumented:
-	ps -ef | grep '$(IMG)' | grep -v grep | awk '{print $$2}' | xargs kill -s SIGUSR1
+	-ps -ef | grep '$(IMG)' | grep -v grep | awk '{print $$2}' | xargs kill -s SIGUSR1
 	sleep 5 # wait for tests to gracefully shut down
+	-KUBECONFIG=$(KIND_KUBECONFIG) kubectl delete -n open-cluster-management lease governance-policy-addon-controller-lock
 	-ps -ef | grep '$(IMG)' | grep -v grep | awk '{print $$2}' | xargs kill
 
 .PHONY: e2e-debug

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -48,6 +48,7 @@ rules:
   - cert-policy-controller
   - config-policy-controller
   - governance-policy-framework
+  - governance-standalone-hub-templating
   - iam-policy-controller
   resources:
   - clustermanagementaddons/finalizers
@@ -60,6 +61,7 @@ rules:
   - cert-policy-controller
   - config-policy-controller
   - governance-policy-framework
+  - governance-standalone-hub-templating
   resources:
   - clustermanagementaddons/status
   - managedclusteraddons/status
@@ -82,6 +84,7 @@ rules:
   - cert-policy-controller
   - config-policy-controller
   - governance-policy-framework
+  - governance-standalone-hub-templating
   - iam-policy-controller
   resources:
   - managedclusteraddons
@@ -147,6 +150,7 @@ rules:
   - cert-policy-controller
   - config-policy-controller
   - governance-policy-framework
+  - governance-standalone-hub-templating
   resources:
   - leases
   verbs:
@@ -193,6 +197,7 @@ rules:
   resourceNames:
   - open-cluster-management:cert-policy-controller-hub
   - open-cluster-management:config-policy-controller-hub
+  - open-cluster-management:governance-standalone-hub-templating
   - open-cluster-management:policy-framework-hub
   resources:
   - clusterroles

--- a/main.go
+++ b/main.go
@@ -35,6 +35,7 @@ import (
 	"open-cluster-management.io/governance-policy-addon-controller/pkg/addon/certpolicy"
 	"open-cluster-management.io/governance-policy-addon-controller/pkg/addon/configpolicy"
 	"open-cluster-management.io/governance-policy-addon-controller/pkg/addon/policyframework"
+	"open-cluster-management.io/governance-policy-addon-controller/pkg/addon/standalonetemplating"
 )
 
 //+kubebuilder:rbac:groups=authorization.k8s.io,resources=subjectaccessreviews,verbs=get;create
@@ -46,24 +47,24 @@ import (
 // RBAC below will need to be updated if/when new policy controllers are added.
 
 //+kubebuilder:rbac:groups=coordination.k8s.io,resources=leases,verbs=create
-//+kubebuilder:rbac:groups=coordination.k8s.io,resources=leases,verbs=get;list;watch;patch;update,resourceNames=governance-policy-framework;config-policy-controller;cert-policy-controller
+//+kubebuilder:rbac:groups=coordination.k8s.io,resources=leases,verbs=get;list;watch;patch;update,resourceNames=governance-policy-framework;config-policy-controller;governance-standalone-hub-templating;cert-policy-controller
 
 //+kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=clusterroles,verbs=create
-//+kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=clusterroles,verbs=get;update;patch;delete,resourceNames="open-cluster-management:policy-framework-hub";"open-cluster-management:config-policy-controller-hub";"open-cluster-management:cert-policy-controller-hub"
+//+kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=clusterroles,verbs=get;update;patch;delete,resourceNames="open-cluster-management:policy-framework-hub";"open-cluster-management:config-policy-controller-hub";"open-cluster-management:governance-standalone-hub-templating";"open-cluster-management:cert-policy-controller-hub"
 //+kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=rolebindings,verbs=create
-//+kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=rolebindings,verbs=get;update;patch;delete,resourceNames="open-cluster-management:policy-framework-hub";"open-cluster-management:config-policy-controller-hub";"open-cluster-management:cert-policy-controller-hub"
+//+kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=rolebindings,verbs=get;update;patch;delete,resourceNames="open-cluster-management:policy-framework-hub";"open-cluster-management:config-policy-controller-hub";"open-cluster-management:governance-standalone-hub-templating";"open-cluster-management:cert-policy-controller-hub"
 
 // Cannot limit based on resourceNames because the name is dynamic in hosted mode.
 //+kubebuilder:rbac:groups=work.open-cluster-management.io,resources=manifestworks,verbs=create;delete;get;list;patch;update;watch
 
 //+kubebuilder:rbac:groups=addon.open-cluster-management.io,resources=managedclusteraddons,verbs=create
 //+kubebuilder:rbac:groups=addon.open-cluster-management.io,resources=managedclusteraddons,verbs=get;list;watch;update
-//+kubebuilder:rbac:groups=addon.open-cluster-management.io,resources=managedclusteraddons,verbs=delete,resourceNames=config-policy-controller;governance-policy-framework;iam-policy-controller;cert-policy-controller
-//+kubebuilder:rbac:groups=addon.open-cluster-management.io,resources=managedclusteraddons/finalizers,verbs=update,resourceNames=config-policy-controller;governance-policy-framework;iam-policy-controller;cert-policy-controller
-//+kubebuilder:rbac:groups=addon.open-cluster-management.io,resources=managedclusteraddons/status,verbs=update;patch,resourceNames=config-policy-controller;governance-policy-framework;cert-policy-controller
-//+kubebuilder:rbac:groups=addon.open-cluster-management.io,resources=clustermanagementaddons/status,verbs=update;patch,resourceNames=config-policy-controller;governance-policy-framework;cert-policy-controller
+//+kubebuilder:rbac:groups=addon.open-cluster-management.io,resources=managedclusteraddons,verbs=delete,resourceNames=config-policy-controller;governance-policy-framework;governance-standalone-hub-templating;iam-policy-controller;cert-policy-controller
+//+kubebuilder:rbac:groups=addon.open-cluster-management.io,resources=managedclusteraddons/finalizers,verbs=update,resourceNames=config-policy-controller;governance-policy-framework;governance-standalone-hub-templating;iam-policy-controller;cert-policy-controller
+//+kubebuilder:rbac:groups=addon.open-cluster-management.io,resources=managedclusteraddons/status,verbs=update;patch,resourceNames=config-policy-controller;governance-policy-framework;governance-standalone-hub-templating;cert-policy-controller
+//+kubebuilder:rbac:groups=addon.open-cluster-management.io,resources=clustermanagementaddons/status,verbs=update;patch,resourceNames=config-policy-controller;governance-policy-framework;governance-standalone-hub-templating;cert-policy-controller
 
-//+kubebuilder:rbac:groups=addon.open-cluster-management.io,resources=clustermanagementaddons/finalizers,verbs=update,resourceNames=config-policy-controller;governance-policy-framework;iam-policy-controller;cert-policy-controller
+//+kubebuilder:rbac:groups=addon.open-cluster-management.io,resources=clustermanagementaddons/finalizers,verbs=update,resourceNames=config-policy-controller;governance-policy-framework;governance-standalone-hub-templating;iam-policy-controller;cert-policy-controller
 //+kubebuilder:rbac:groups=addon.open-cluster-management.io,resources=addondeploymentconfigs,verbs=get;list;watch
 
 // Permissions required for policy-framework
@@ -127,6 +128,7 @@ func runController(ctx context.Context, controllerContext *controllercmd.Control
 	agentFuncs := []func(context.Context, addonmanager.AddonManager, *controllercmd.ControllerContext) error{
 		policyframework.GetAndAddAgent,
 		configpolicy.GetAndAddAgent,
+		standalonetemplating.GetAndAddAgent,
 		certpolicy.GetAndAddAgent,
 	}
 

--- a/pkg/addon/common.go
+++ b/pkg/addon/common.go
@@ -75,17 +75,24 @@ func NewRegistrationOption(
 	addonName string,
 	agentPermissionFiles []string,
 	filesystem embed.FS,
+	useClusterRole bool,
 ) *agent.RegistrationOption {
 	applyManifestFromFile := func(file, clusterName string,
 		kubeclient *kubernetes.Clientset, recorder events.Recorder,
 	) error {
+		groupIdx := 0 // 0 is a cluster-specific group
+
+		if useClusterRole {
+			groupIdx = 1 // 1 is a group for the entire addon
+		}
+
 		groups := agent.DefaultGroups(clusterName, addonName)
 		config := struct {
 			ClusterName string
 			Group       string
 		}{
 			ClusterName: clusterName,
-			Group:       groups[0],
+			Group:       groups[groupIdx],
 		}
 
 		results := resourceapply.ApplyDirectly(context.Background(),

--- a/pkg/addon/configpolicy/manifests/managedclusterchart/templates/deployment.yaml
+++ b/pkg/addon/configpolicy/manifests/managedclusterchart/templates/deployment.yaml
@@ -66,6 +66,9 @@ spec:
           - --operator-policy-default-namespace={{ .Values.operatorPolicy.defaultNamespace }}
           {{- end }}
           {{- end }}
+          {{- if ne .Values.standaloneHubTemplatingSecret "" }}
+          - --standalone-hub-templates-kubeconfig-path=/var/run/standalone-hub-templating/kubeconfig
+          {{- end }}
         env:
           - name: WATCH_NAMESPACE
             {{- if eq .Values.installMode "Hosted" }}
@@ -139,6 +142,11 @@ spec:
             name: managed-kubeconfig-secret
             readOnly: true
           {{- end }}
+          {{- if ne .Values.standaloneHubTemplatingSecret "" }}
+          - mountPath: "/var/run/standalone-hub-templating"
+            name: standalone-hub-templating-kubeconfig
+            readOnly: true
+          {{- end }}
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:
@@ -159,6 +167,11 @@ spec:
         - name: metrics-cert
           secret:
             secretName: {{ include "controller.fullname" . }}-metrics
+        {{- end }}
+        {{- if ne .Values.standaloneHubTemplatingSecret "" }}
+        - name: standalone-hub-templating-kubeconfig
+          secret:
+            secretName: {{ .Values.standaloneHubTemplatingSecret }}
         {{- end }}
       {{- if .Values.global.imagePullSecret }}
       imagePullSecrets:

--- a/pkg/addon/configpolicy/manifests/managedclusterchart/values.yaml
+++ b/pkg/addon/configpolicy/manifests/managedclusterchart/values.yaml
@@ -14,6 +14,8 @@ args:
   clientBurst: 45
 hubKubeConfigSecret: config-policy-controller-hub-kubeconfig
 
+standaloneHubTemplatingSecret: ""
+
 operatorPolicy:
   disabled: false
   defaultNamespace: ""

--- a/pkg/addon/policyframework/agent_addon.go
+++ b/pkg/addon/policyframework/agent_addon.go
@@ -242,7 +242,8 @@ func GetAgentAddon(ctx context.Context, controllerContext *controllercmd.Control
 		controllerContext,
 		addonName,
 		agentPermissionFiles,
-		FS)
+		FS,
+		false)
 
 	addonClient, err := addonv1alpha1client.NewForConfig(controllerContext.KubeConfig)
 	if err != nil {

--- a/pkg/addon/standalonetemplating/manifests/hubpermissions/role.yaml
+++ b/pkg/addon/standalonetemplating/manifests/hubpermissions/role.yaml
@@ -1,0 +1,34 @@
+# Copyright Contributors to the Open Cluster Management project
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: open-cluster-management:governance-standalone-hub-templating
+rules:
+# Rules for maintaining the lease on the hub
+- apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  resourceNames:
+  - governance-policy-framework
+  verbs:
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - create
+# Base permissions for hub templates, all others must be configured by users
+- apiGroups:
+  - cluster.open-cluster-management.io
+  resources:
+  - managedclusters
+  verbs:
+  - get
+  - list
+  - watch

--- a/pkg/addon/standalonetemplating/manifests/hubpermissions/rolebinding.yaml
+++ b/pkg/addon/standalonetemplating/manifests/hubpermissions/rolebinding.yaml
@@ -1,0 +1,14 @@
+# Copyright Contributors to the Open Cluster Management project
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: "open-cluster-management:governance-standalone-hub-templating"
+  namespace: "{{ .ClusterName }}"
+roleRef:
+  kind: ClusterRole
+  name: open-cluster-management:governance-standalone-hub-templating
+  apiGroup: rbac.authorization.k8s.io
+subjects:
+  - apiGroup: rbac.authorization.k8s.io
+    kind: Group
+    name: "{{ .Group }}"

--- a/pkg/addon/standalonetemplating/manifests/managedclusterchart/Chart.yaml
+++ b/pkg/addon/standalonetemplating/manifests/managedclusterchart/Chart.yaml
@@ -1,0 +1,7 @@
+# Copyright Contributors to the Open Cluster Management project
+
+apiVersion: v1
+description: A Helm chart for the Policy Standalone Hub Templating feature in open-cluster-management
+name: governance-standalone-hub-templating
+version: 2.13.0
+appVersion: "2.13.0"

--- a/pkg/addon/standalonetemplating/manifests/managedclusterchart/templates/_helpers.tpl
+++ b/pkg/addon/standalonetemplating/manifests/managedclusterchart/templates/_helpers.tpl
@@ -1,0 +1,53 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "controller.name" -}}
+    {{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "controller.fullname" -}}
+    {{- if .Values.fullnameOverride -}}
+        {{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+    {{- else -}}
+        {{- $name := default .Chart.Name .Values.nameOverride -}}
+        {{- if contains $name .Release.Name -}}
+            {{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+        {{- else -}}
+            {{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+        {{- end -}}
+    {{- end -}}
+{{- end -}}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "controller.chart" -}}
+    {{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create role name used in cluster role and binding
+*/}}
+{{- define "controller.rolename" -}}
+    {{- .Values.org }}:{{ template "controller.fullname" . -}}
+{{- end -}}
+
+{{/*
+Create role name used in role and binding for leader election
+*/}}
+{{- define "controller.leaderrolename" -}}
+    {{ template "controller.fullname" . }}-leader
+{{- end -}}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "controller.serviceAccountName" -}}
+    {{- template "controller.fullname" . -}}-sa
+{{- end -}}

--- a/pkg/addon/standalonetemplating/manifests/managedclusterchart/templates/secret.yaml
+++ b/pkg/addon/standalonetemplating/manifests/managedclusterchart/templates/secret.yaml
@@ -1,0 +1,15 @@
+# Copyright Contributors to the Open Cluster Management project
+
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "controller.fullname" . }}-info
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: {{ include "controller.fullname" . }}
+    chart: {{ include "controller.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+    addon.open-cluster-management.io/hosted-manifest-location: hosting
+stringData:
+  hub.group: {{ .Values.hubGroup }}

--- a/pkg/addon/standalonetemplating/manifests/managedclusterchart/values.yaml
+++ b/pkg/addon/standalonetemplating/manifests/managedclusterchart/values.yaml
@@ -1,0 +1,7 @@
+# Copyright Contributors to the Open Cluster Management project
+
+fullnameOverride: null
+nameOverride: null
+org: open-cluster-management
+
+hubGroup: ""

--- a/test/e2e/case3_standalonetemplating_test.go
+++ b/test/e2e/case3_standalonetemplating_test.go
@@ -1,0 +1,105 @@
+// Copyright Contributors to the Open Cluster Management project
+
+package e2e
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+const (
+	case3ManagedClusterAddOnCR           string = "../resources/standalonetemplating_addon_cr.yaml"
+	case3ClusterManagementAddOnDefaultCR string = "../resources/standalonetemplating_clustermanagementaddon.yaml"
+	case3SecretName                      string = "governance-standalone-hub-templating-info"
+)
+
+var _ = Describe("Test config-policy-controller deployment with standalone templating", Ordered, func() {
+	BeforeAll(func() {
+		By("Deploying the default config-policy-controller and governance-standalone-hub-templating " +
+			"ClusterManagementAddons to the hub cluster")
+		Kubectl("apply", "-f", case2ClusterManagementAddOnCRDefault)
+		Kubectl("apply", "-f", case3ClusterManagementAddOnDefaultCR)
+	})
+
+	AfterAll(func() {
+		By("Deleting the default config-policy-controller and governance-standalone-hub-templating " +
+			"ClusterManagementAddons from the hub cluster")
+		Kubectl("delete", "-f", case2ClusterManagementAddOnCRDefault)
+		Kubectl("delete", "-f", case3ClusterManagementAddOnDefaultCR)
+
+		By("Deleting the default config-policy-controller and governance-standalone-hub-templating " +
+			"ManagedClusterAddons on each cluster")
+		for _, cluster := range managedClusterList {
+			Kubectl("delete", "-n", cluster.clusterName, "-f", case2ManagedClusterAddOnCR, "--ignore-not-found=true")
+			Kubectl("delete", "-n", cluster.clusterName, "-f", case3ManagedClusterAddOnCR, "--ignore-not-found=true")
+		}
+	})
+
+	It("should not have hub templating enabled when the standalone-templating addon does not exist", func() {
+		for _, cluster := range managedClusterList {
+			logPrefix := cluster.clusterType + " " + cluster.clusterName + ": "
+			By(logPrefix + "deploying the default config-policy-controller managedclusteraddon")
+			Kubectl("apply", "-n", cluster.clusterName, "-f", case2ManagedClusterAddOnCR)
+
+			By(logPrefix + "verifying the standalone-hub-templates arg is not set")
+
+			deploy := GetWithTimeout(
+				cluster.clusterClient, gvrDeployment, case2DeploymentName, addonNamespace, true, 60,
+			)
+			Expect(deploy).NotTo(BeNil())
+
+			Eventually(func(g Gomega) []string {
+				deploy = GetWithTimeout(
+					cluster.clusterClient, gvrDeployment, case2DeploymentName, addonNamespace, true, 30,
+				)
+				containers, _, _ := unstructured.NestedSlice(deploy.Object, "spec", "template", "spec", "containers")
+				g.Expect(containers).Should(HaveLen(1))
+
+				cont, ok := containers[0].(map[string]any)
+				g.Expect(ok).To(BeTrue())
+
+				args, _, _ := unstructured.NestedStringSlice(cont, "args")
+
+				return args
+			}, 60, 1).ShouldNot(ContainElement(ContainSubstring("standalone-hub-templates")))
+		}
+	})
+
+	It("should have hub templating enabled after the standalone-templating addon is created", func() {
+		for _, cluster := range managedClusterList {
+			logPrefix := cluster.clusterType + " " + cluster.clusterName + ": "
+			By(logPrefix + "deploying the default governance-standalone-hub-templating managedclusteraddon")
+			Kubectl("apply", "-n", cluster.clusterName, "-f", case3ManagedClusterAddOnCR)
+
+			By(logPrefix + "verifying the standalone-hub-templates arg is set")
+
+			deploy := GetWithTimeout(
+				cluster.clusterClient, gvrDeployment, case2DeploymentName, addonNamespace, true, 60,
+			)
+			Expect(deploy).NotTo(BeNil())
+
+			Eventually(func(g Gomega) []string {
+				deploy = GetWithTimeout(
+					cluster.clusterClient, gvrDeployment, case2DeploymentName, addonNamespace, true, 30,
+				)
+				containers, _, _ := unstructured.NestedSlice(deploy.Object, "spec", "template", "spec", "containers")
+				g.Expect(containers).Should(HaveLen(1))
+
+				cont, ok := containers[0].(map[string]any)
+				g.Expect(ok).To(BeTrue())
+
+				args, _, _ := unstructured.NestedStringSlice(cont, "args")
+
+				return args
+			}, 60, 1).Should(ContainElement(ContainSubstring("standalone-hub-templates")))
+
+			By(logPrefix + "verifying the " + case3SecretName + " secret was created")
+
+			secret := GetWithTimeout(
+				cluster.clusterClient, gvrSecret, case3SecretName, addonNamespace, true, 30,
+			)
+			Expect(secret).NotTo(BeNil())
+		}
+	})
+})

--- a/test/resources/standalonetemplating_addon_cr.yaml
+++ b/test/resources/standalonetemplating_addon_cr.yaml
@@ -1,0 +1,6 @@
+apiVersion: addon.open-cluster-management.io/v1alpha1
+kind: ManagedClusterAddOn
+metadata:
+  name: governance-standalone-hub-templating
+spec:
+  installNamespace: open-cluster-management-agent-addon

--- a/test/resources/standalonetemplating_clustermanagementaddon.yaml
+++ b/test/resources/standalonetemplating_clustermanagementaddon.yaml
@@ -1,0 +1,4 @@
+apiVersion: addon.open-cluster-management.io/v1alpha1
+kind: ClusterManagementAddOn
+metadata:
+  name: governance-standalone-hub-templating


### PR DESCRIPTION
This addon provides a mechanism for the configuration-policy-controller (including both ConfigurationPolicy and OperatorPolicy) to access resources on the hub cluster in order to resolve "hub templates." The addon itself is very small, it is just some base RBAC resources and a secret on the managed cluster to help the user identify how to configure additional permissions. Mainly, the config-policy-controller needs to be configured to mount the new addon's hub kubeconfig and utilize it.

Refs:
 - https://issues.redhat.com/browse/ACM-16089

Signed-off-by: Justin Kulikauskas <jkulikau@redhat.com>
(cherry picked from commit 9d1a7372f38e89b7d42c766808960f8160b14555)

Closes: https://github.com/stolostron/governance-policy-addon-controller/issues/790