### PR TITLE
Fix: add missing `resources` key (CertPolicy)

### DIFF
--- a/pkg/addon/certpolicy/manifests/managedclusterchart/values.yaml
+++ b/pkg/addon/certpolicy/manifests/managedclusterchart/values.yaml
@@ -47,10 +47,11 @@ prometheus:
 global:
   resourceRequirements:
     - containerIDRegex: ^.+:.+:.+$
-      requests:
-        memory: "150Mi"
-      limits:
-        memory: "300Mi"
+      resources:
+        requests:
+          memory: "150Mi"
+        limits:
+          memory: "300Mi"
   imagePullPolicy: IfNotPresent
   imagePullSecret: open-cluster-management-image-pull-credentials
   imageOverrides:

--- a/test/e2e/case4_cert_deployment_test.go
+++ b/test/e2e/case4_cert_deployment_test.go
@@ -170,6 +170,10 @@ var _ = Describe("Test cert-policy-controller deployment", Ordered, func() {
 	It("should create a cert-policy-controller deployment with resource requirements on the managed cluster",
 		func(ctx SpecContext) {
 			deploymentConfigTests := map[string]map[string]interface{}{
+				"../resources/addondeploymentconfig_empty.yaml": {
+					"requests": map[string]interface{}{"memory": "150Mi"},
+					"limits":   map[string]interface{}{"memory": "300Mi"},
+				},
 				"../resources/addondeploymentconfig_resourceRequirements_individual.yaml": {
 					"requests": map[string]interface{}{"memory": "60Mi"},
 					"limits":   map[string]interface{}{"memory": "120Mi"},


### PR DESCRIPTION
Related to:
- #814 
- https://github.com/open-cluster-management-io/governance-policy-addon-controller/pull/198