### PR TITLE
[manual-sync] Use informers for faster lookups

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -187,7 +187,19 @@ rules:
   - update
 - apiGroups:
   - rbac.authorization.k8s.io
+  resourceNames:
+  - open-cluster-management:governance-standalone-hub-templating
   resources:
+  - clusterrolebindings
+  verbs:
+  - delete
+  - get
+  - patch
+  - update
+- apiGroups:
+  - rbac.authorization.k8s.io
+  resources:
+  - clusterrolebindings
   - clusterroles
   - rolebindings
   verbs:

--- a/main.go
+++ b/main.go
@@ -58,6 +58,8 @@ import (
 
 //+kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=clusterroles,verbs=create
 //+kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=clusterroles,verbs=get;update;patch;delete,resourceNames="open-cluster-management:policy-framework-hub";"open-cluster-management:config-policy-controller-hub";"open-cluster-management:governance-standalone-hub-templating";"open-cluster-management:cert-policy-controller-hub"
+//+kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=clusterrolebindings,verbs=create
+//+kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=clusterrolebindings,verbs=get;update;patch;delete,resourceNames="open-cluster-management:governance-standalone-hub-templating"
 //+kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=rolebindings,verbs=create
 //+kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=rolebindings,verbs=get;update;patch;delete,resourceNames="open-cluster-management:policy-framework-hub";"open-cluster-management:config-policy-controller-hub";"open-cluster-management:governance-standalone-hub-templating";"open-cluster-management:cert-policy-controller-hub"
 

--- a/pkg/addon/common.go
+++ b/pkg/addon/common.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"os"
 	"strconv"
-	"time"
 
 	"github.com/blang/semver/v4"
 	"github.com/openshift/library-go/pkg/assets"
@@ -18,13 +17,10 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/kubernetes/scheme"
-	"k8s.io/client-go/rest"
 	"open-cluster-management.io/addon-framework/pkg/addonmanager"
 	"open-cluster-management.io/addon-framework/pkg/agent"
 	"open-cluster-management.io/addon-framework/pkg/utils"
 	addonapiv1alpha1 "open-cluster-management.io/api/addon/v1alpha1"
-	clusterv1client "open-cluster-management.io/api/client/cluster/clientset/versioned"
-	clusterv1informers "open-cluster-management.io/api/client/cluster/informers/externalversions"
 	clusterv1 "open-cluster-management.io/api/cluster/v1"
 	ctrl "sigs.k8s.io/controller-runtime"
 )
@@ -181,18 +177,6 @@ func GetAndAddAgent(
 	}
 
 	return nil
-}
-
-func GetManagedClusterClient(ctx context.Context, kubeConfig *rest.Config) (*clusterv1client.Clientset, error) {
-	clusterClient, err := clusterv1client.NewForConfig(kubeConfig)
-	if err != nil {
-		return nil, err
-	}
-
-	clusterInformers := clusterv1informers.NewSharedInformerFactory(clusterClient, 10*time.Minute)
-	go clusterInformers.Cluster().V1().ManagedClusters().Informer().Run(ctx.Done())
-
-	return clusterClient, nil
 }
 
 // PolicyAgentAddon wraps the AgentAddon created from the addonfactory to override some behavior

--- a/pkg/addon/configpolicy/agent_addon.go
+++ b/pkg/addon/configpolicy/agent_addon.go
@@ -6,17 +6,21 @@ import (
 	"fmt"
 	"os"
 	"strconv"
+	"time"
 
 	"github.com/openshift/library-go/pkg/controller/controllercmd"
 	"k8s.io/apimachinery/pkg/api/errors"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"open-cluster-management.io/addon-framework/pkg/addonfactory"
 	"open-cluster-management.io/addon-framework/pkg/addonmanager"
 	"open-cluster-management.io/addon-framework/pkg/agent"
 	"open-cluster-management.io/addon-framework/pkg/utils"
 	addonapiv1alpha1 "open-cluster-management.io/api/addon/v1alpha1"
 	addonv1alpha1client "open-cluster-management.io/api/client/addon/clientset/versioned"
+	addoninformers "open-cluster-management.io/api/client/addon/informers/externalversions"
+	addonlistersv1alpha1 "open-cluster-management.io/api/client/addon/listers/addon/v1alpha1"
 	clusterv1client "open-cluster-management.io/api/client/cluster/clientset/versioned"
+	clusterv1informers "open-cluster-management.io/api/client/cluster/informers/externalversions"
+	clusterlistersv1 "open-cluster-management.io/api/client/cluster/listers/cluster/v1"
 	clusterv1 "open-cluster-management.io/api/cluster/v1"
 	ctrl "sigs.k8s.io/controller-runtime"
 
@@ -66,9 +70,8 @@ var agentPermissionFiles = []string{
 }
 
 func getValues(
-	ctx context.Context,
-	clusterClient *clusterv1client.Clientset,
-	addonClient *addonv1alpha1client.Clientset,
+	clusterClient clusterlistersv1.ManagedClusterLister,
+	addonClient addonlistersv1alpha1.ManagedClusterAddOnLister,
 ) func(*clusterv1.ManagedCluster, *addonapiv1alpha1.ManagedClusterAddOn) (addonfactory.Values, error) {
 	return func(
 		cluster *clusterv1.ManagedCluster, addon *addonapiv1alpha1.ManagedClusterAddOn,
@@ -105,9 +108,7 @@ func getValues(
 
 		hostingClusterName := addon.Annotations["addon.open-cluster-management.io/hosting-cluster-name"]
 		if hostingClusterName != "" {
-			hostingCluster, err := clusterClient.ClusterV1().ManagedClusters().Get(
-				ctx, hostingClusterName, metav1.GetOptions{},
-			)
+			hostingCluster, err := clusterClient.Get(hostingClusterName)
 			if err != nil {
 				return nil, err
 			}
@@ -117,9 +118,7 @@ func getValues(
 			userValues.HostingKubernetesDistribution = userValues.KubernetesDistribution
 		}
 
-		_, err := addonClient.AddonV1alpha1().ManagedClusterAddOns(addon.Namespace).Get(
-			ctx, standaloneTemplatingAddonName, metav1.GetOptions{},
-		)
+		_, err := addonClient.ManagedClusterAddOns(addon.Namespace).Get(standaloneTemplatingAddonName)
 		if !errors.IsNotFound(err) {
 			if err != nil {
 				return nil, err
@@ -252,10 +251,18 @@ func GetAgentAddon(ctx context.Context, controllerContext *controllercmd.Control
 		return nil, fmt.Errorf("failed to retrieve addon client: %w", err)
 	}
 
-	clusterClient, err := policyaddon.GetManagedClusterClient(ctx, controllerContext.KubeConfig)
+	addonInformer := addoninformers.NewSharedInformerFactory(addonClient, 10*time.Minute).
+		Addon().V1alpha1().ManagedClusterAddOns()
+	go addonInformer.Informer().Run(ctx.Done())
+
+	clusterClient, err := clusterv1client.NewForConfig(controllerContext.KubeConfig)
 	if err != nil {
 		return nil, fmt.Errorf("failed to initialize a managed cluster client: %w", err)
 	}
+
+	clusterInformer := clusterv1informers.NewSharedInformerFactory(clusterClient, 10*time.Minute).
+		Cluster().V1().ManagedClusters()
+	go clusterInformer.Informer().Run(ctx.Done())
 
 	return addonfactory.NewAgentAddonFactory(addonName, FS, "manifests/managedclusterchart").
 		WithConfigGVRs(utils.AddOnDeploymentConfigGVR).
@@ -266,7 +273,7 @@ func GetAgentAddon(ctx context.Context, controllerContext *controllercmd.Control
 				addonfactory.ToAddOnResourceRequirementsValues,
 				addonfactory.ToAddOnCustomizedVariableValues,
 			),
-			getValues(ctx, clusterClient, addonClient),
+			getValues(clusterInformer.Lister(), addonInformer.Lister()),
 			addonfactory.GetValuesFromAddonAnnotation,
 			mandateValues,
 		).

--- a/pkg/addon/policyframework/agent_addon.go
+++ b/pkg/addon/policyframework/agent_addon.go
@@ -7,9 +7,9 @@ import (
 	"os"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/openshift/library-go/pkg/controller/controllercmd"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"open-cluster-management.io/addon-framework/pkg/addonfactory"
 	"open-cluster-management.io/addon-framework/pkg/addonmanager"
 	"open-cluster-management.io/addon-framework/pkg/agent"
@@ -17,6 +17,8 @@ import (
 	addonapiv1alpha1 "open-cluster-management.io/api/addon/v1alpha1"
 	addonv1alpha1client "open-cluster-management.io/api/client/addon/clientset/versioned"
 	clusterv1client "open-cluster-management.io/api/client/cluster/clientset/versioned"
+	clusterv1informers "open-cluster-management.io/api/client/cluster/informers/externalversions"
+	clusterlistersv1 "open-cluster-management.io/api/client/cluster/listers/cluster/v1"
 	clusterv1 "open-cluster-management.io/api/cluster/v1"
 	ctrl "sigs.k8s.io/controller-runtime"
 
@@ -66,7 +68,7 @@ type userValues struct {
 	UserArgs                      UserArgs                 `json:"args"`
 }
 
-func getValues(ctx context.Context, clusterClient *clusterv1client.Clientset) func(*clusterv1.ManagedCluster,
+func getValues(clusterClient clusterlistersv1.ManagedClusterLister) func(*clusterv1.ManagedCluster,
 	*addonapiv1alpha1.ManagedClusterAddOn,
 ) (addonfactory.Values, error) {
 	return func(
@@ -115,9 +117,7 @@ func getValues(ctx context.Context, clusterClient *clusterv1client.Clientset) fu
 		userValues.KubernetesDistribution = policyaddon.GetClusterVendor(cluster)
 
 		if hostingClusterName != "" {
-			hostingCluster, err := clusterClient.ClusterV1().ManagedClusters().Get(
-				ctx, hostingClusterName, metav1.GetOptions{},
-			)
+			hostingCluster, err := clusterClient.Get(hostingClusterName)
 			if err != nil {
 				return nil, err
 			}
@@ -249,10 +249,14 @@ func GetAgentAddon(ctx context.Context, controllerContext *controllercmd.Control
 		return nil, fmt.Errorf("failed to retrieve addon client: %w", err)
 	}
 
-	clusterClient, err := policyaddon.GetManagedClusterClient(ctx, controllerContext.KubeConfig)
+	clusterClient, err := clusterv1client.NewForConfig(controllerContext.KubeConfig)
 	if err != nil {
 		return nil, fmt.Errorf("failed to initialize a managed cluster client: %w", err)
 	}
+
+	clusterInformer := clusterv1informers.NewSharedInformerFactory(clusterClient, 10*time.Minute).
+		Cluster().V1().ManagedClusters()
+	go clusterInformer.Informer().Run(ctx.Done())
 
 	return addonfactory.NewAgentAddonFactory(addonName, FS, "manifests/managedclusterchart").
 		WithConfigGVRs(utils.AddOnDeploymentConfigGVR).
@@ -263,7 +267,7 @@ func GetAgentAddon(ctx context.Context, controllerContext *controllercmd.Control
 				addonfactory.ToAddOnResourceRequirementsValues,
 				addonfactory.ToAddOnCustomizedVariableValues,
 			),
-			getValues(ctx, clusterClient),
+			getValues(clusterInformer.Lister()),
 			addonfactory.GetValuesFromAddonAnnotation,
 			mandateValues,
 		).

--- a/pkg/addon/standalonetemplating/agent_addon.go
+++ b/pkg/addon/standalonetemplating/agent_addon.go
@@ -13,6 +13,7 @@ import (
 	"open-cluster-management.io/addon-framework/pkg/utils"
 	addonapiv1alpha1 "open-cluster-management.io/api/addon/v1alpha1"
 	addonv1alpha1client "open-cluster-management.io/api/client/addon/clientset/versioned"
+	clusterv1client "open-cluster-management.io/api/client/cluster/clientset/versioned"
 	clusterv1 "open-cluster-management.io/api/cluster/v1"
 
 	policyaddon "open-cluster-management.io/governance-policy-addon-controller/pkg/addon"
@@ -35,7 +36,8 @@ var agentPermissionFiles = []string{
 	"manifests/hubpermissions/rolebinding.yaml",
 }
 
-func getValues(_ *clusterv1.ManagedCluster,
+func getValues(
+	_ *clusterv1.ManagedCluster,
 	addon *addonapiv1alpha1.ManagedClusterAddOn,
 ) (addonfactory.Values, error) {
 	values := addonfactory.Values{}
@@ -46,7 +48,7 @@ func getValues(_ *clusterv1.ManagedCluster,
 	return values, nil
 }
 
-func getAgentAddon(ctx context.Context, controllerContext *controllercmd.ControllerContext) (agent.AgentAddon, error) {
+func getAgentAddon(controllerContext *controllercmd.ControllerContext) (agent.AgentAddon, error) {
 	registrationOption := policyaddon.NewRegistrationOption(
 		controllerContext,
 		addonName,
@@ -59,7 +61,7 @@ func getAgentAddon(ctx context.Context, controllerContext *controllercmd.Control
 		return nil, fmt.Errorf("failed to retrieve addon client: %w", err)
 	}
 
-	clusterClient, err := policyaddon.GetManagedClusterClient(ctx, controllerContext.KubeConfig)
+	clusterClient, err := clusterv1client.NewForConfig(controllerContext.KubeConfig)
 	if err != nil {
 		return nil, fmt.Errorf("failed to initialize a managed cluster client: %w", err)
 	}
@@ -99,9 +101,9 @@ func (sa *StandaloneAgentAddon) Manifests(
 }
 
 func GetAndAddAgent(
-	ctx context.Context, mgr addonmanager.AddonManager, controllerContext *controllercmd.ControllerContext,
+	_ context.Context, mgr addonmanager.AddonManager, controllerContext *controllercmd.ControllerContext,
 ) error {
-	agentAddon, err := getAgentAddon(ctx, controllerContext)
+	agentAddon, err := getAgentAddon(controllerContext)
 	if err != nil {
 		return fmt.Errorf("failed getting the %v agent addon: %w", addonName, err)
 	}


### PR DESCRIPTION
Sync of https://github.com/open-cluster-management-io/governance-policy-addon-controller/pull/199

Plus the similar change for cert-policy-controller.

Ref: https://issues.redhat.com/browse/ACM-18029

Closes https://github.com/stolostron/governance-policy-addon-controller/issues/830