### PR TITLE
Bump to Go v1.24

### DIFF
--- a/.ci-operator.yaml
+++ b/.ci-operator.yaml
@@ -1,4 +1,4 @@
 build_root_image:
   name: builder
   namespace: stolostron
-  tag: go1.23-linux
+  tag: go1.24-linux

--- a/build/Dockerfile.rhtap
+++ b/build/Dockerfile.rhtap
@@ -1,7 +1,7 @@
 # Stage 1: Use image builder to build the target binaries
 # Copyright Contributors to the Open Cluster Management project
 
-FROM brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_9_1.23 AS builder
+FROM brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_9_1.24 AS builder
 
 ENV COMPONENT=governance-policy-addon-controller
 ENV REPO_PATH=/go/src/github.com/stolostron/${COMPONENT}


### PR DESCRIPTION
This should also resolve the current build failure:
```
go: go.mod requires go >= 1.24.0 (running go 1.23.9; GOTOOLCHAIN=local)
```
- https://github.com/stolostron/governance-policy-addon-controller/runs/50191629022
- https://konflux-ui.apps.stone-prd-rh01.pg1f.p1.openshiftapps.com/ns/crt-redhat-acm-tenant/pipelinerun/governance-policy-addon-controller-acm-215-on-push-2wgmq

ref: https://issues.redhat.com/browse/ACM-24072