### PR TITLE
chore: remove `iam-policy-controller` RBAC

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -50,7 +50,6 @@ rules:
   - config-policy-controller
   - governance-policy-framework
   - governance-standalone-hub-templating
-  - iam-policy-controller
   resources:
   - clustermanagementaddons/finalizers
   - managedclusteraddons/finalizers
@@ -86,7 +85,6 @@ rules:
   - config-policy-controller
   - governance-policy-framework
   - governance-standalone-hub-templating
-  - iam-policy-controller
   resources:
   - managedclusteraddons
   verbs:

--- a/main.go
+++ b/main.go
@@ -68,12 +68,12 @@ import (
 
 //+kubebuilder:rbac:groups=addon.open-cluster-management.io,resources=managedclusteraddons,verbs=create
 //+kubebuilder:rbac:groups=addon.open-cluster-management.io,resources=managedclusteraddons,verbs=get;list;watch;update
-//+kubebuilder:rbac:groups=addon.open-cluster-management.io,resources=managedclusteraddons,verbs=delete,resourceNames=config-policy-controller;governance-policy-framework;governance-standalone-hub-templating;iam-policy-controller;cert-policy-controller
-//+kubebuilder:rbac:groups=addon.open-cluster-management.io,resources=managedclusteraddons/finalizers,verbs=update,resourceNames=config-policy-controller;governance-policy-framework;governance-standalone-hub-templating;iam-policy-controller;cert-policy-controller
+//+kubebuilder:rbac:groups=addon.open-cluster-management.io,resources=managedclusteraddons,verbs=delete,resourceNames=config-policy-controller;governance-policy-framework;governance-standalone-hub-templating;cert-policy-controller
+//+kubebuilder:rbac:groups=addon.open-cluster-management.io,resources=managedclusteraddons/finalizers,verbs=update,resourceNames=config-policy-controller;governance-policy-framework;governance-standalone-hub-templating;cert-policy-controller
 //+kubebuilder:rbac:groups=addon.open-cluster-management.io,resources=managedclusteraddons/status,verbs=update;patch,resourceNames=config-policy-controller;governance-policy-framework;governance-standalone-hub-templating;cert-policy-controller
 //+kubebuilder:rbac:groups=addon.open-cluster-management.io,resources=clustermanagementaddons/status,verbs=update;patch,resourceNames=config-policy-controller;governance-policy-framework;governance-standalone-hub-templating;cert-policy-controller
 
-//+kubebuilder:rbac:groups=addon.open-cluster-management.io,resources=clustermanagementaddons/finalizers,verbs=update,resourceNames=config-policy-controller;governance-policy-framework;governance-standalone-hub-templating;iam-policy-controller;cert-policy-controller
+//+kubebuilder:rbac:groups=addon.open-cluster-management.io,resources=clustermanagementaddons/finalizers,verbs=update,resourceNames=config-policy-controller;governance-policy-framework;governance-standalone-hub-templating;cert-policy-controller
 //+kubebuilder:rbac:groups=addon.open-cluster-management.io,resources=addondeploymentconfigs,verbs=get;list;watch
 
 // Permissions required for policy-framework


### PR DESCRIPTION
At this point, we ought to be far enough out from its removal that it should no longer be necessary to have the permissions to clean up the IAM policy objects.
