### PR TITLE
feat: add grc network policies

### DIFF
--- a/pkg/addon/certpolicy/agent_addon.go
+++ b/pkg/addon/certpolicy/agent_addon.go
@@ -62,6 +62,9 @@ func getSkeletonValues() certPolicyUserValues {
 					ImageOverrides: map[string]string{
 						"cert_policy_controller": os.Getenv("CERT_POLICY_CONTROLLER_IMAGE"),
 					},
+					NetworkPolicies: &policyaddon.NetworkPolicies{
+						Enabled: policyaddon.GetNetworkPoliciesEnabled(),
+					},
 				},
 			},
 		},
@@ -76,12 +79,12 @@ func getValuesFromAnnotations(
 	) (addonfactory.Values, error) {
 		userValues := getSkeletonValues()
 
-		err := userValues.CommonValues.SetCommonValues(cluster, addon, clusterClient)
+		err := userValues.SetCommonValues(cluster, addon, clusterClient)
 		if err != nil {
 			return nil, err
 		}
 
-		if err := userValues.CommonValues.SetCommonValuesFromAnnotations(addon); err != nil {
+		if err := userValues.SetCommonValuesFromAnnotations(addon); err != nil {
 			log.Error(err, "failed to set common values from annotations")
 		}
 
@@ -92,7 +95,7 @@ func getValuesFromAnnotations(
 func getValuesFromCustomizedVariableValues(config addonapiv1beta1.AddOnDeploymentConfig) (addonfactory.Values, error) {
 	userValues := getSkeletonValues()
 
-	userValuesMap, err := userValues.CommonValues.SetCommonValuesFromCustomizedVariables(config)
+	userValuesMap, err := userValues.SetCommonValuesFromCustomizedVariables(config)
 	if err != nil {
 		log.Error(err, "error setting common addon values from customized variables")
 	}

--- a/pkg/addon/certpolicy/manifests/managedclusterchart/templates/network_policy.yaml
+++ b/pkg/addon/certpolicy/manifests/managedclusterchart/templates/network_policy.yaml
@@ -1,0 +1,53 @@
+# Copyright Contributors to the Open Cluster Management project
+
+# NetworkPolicy for cert-policy-controller
+
+{{- if and .Values.global.networkPolicies.enabled .Values.networkPolicies }}
+
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: cert-policy-controller-network-policy
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: {{ include "controller.fullname" . }}
+    chart: {{ include "controller.chart" . }}
+spec:
+  podSelector:
+    matchLabels:
+      app: {{ include "controller.fullname" . }}
+  policyTypes:
+    - Ingress
+    - Egress
+
+  # Ingress Rules
+  ingress:
+  # Metrics ingress from monitoring namespace on port 8443 (secure metrics on OpenShift)
+  {{- if and .Values.prometheus.enabled (eq .Values.hostingKubernetesDistribution "OpenShift") }}
+  - ports:
+    - protocol: TCP
+      port: 8443
+  {{- else if .Values.prometheus.enabled }}
+  # Metrics ingress from monitoring namespace on port 8383
+  - ports:
+    - protocol: TCP
+      port: 8383
+  {{- end }}
+  egress:
+    # DNS resolution
+    - ports:
+        - protocol: UDP
+          port: 53
+        - protocol: TCP
+          port: 53
+        - protocol: UDP
+          port: 5353
+        - protocol: TCP
+          port: 5353
+    # Kubernetes API server access
+    - ports:
+        - protocol: TCP
+          port: 443
+        - protocol: TCP
+          port: 6443
+{{- end }}

--- a/pkg/addon/certpolicy/manifests/managedclusterchart/values.yaml
+++ b/pkg/addon/certpolicy/manifests/managedclusterchart/values.yaml
@@ -15,6 +15,8 @@ logEncoder: console
 
 hubKubeConfigSecret: cert-policy-controller-hub-kubeconfig
 
+networkPolicies: true
+
 affinity: {}
 
 tolerations:

--- a/pkg/addon/common.go
+++ b/pkg/addon/common.go
@@ -36,6 +36,7 @@ const (
 	ClientQPSAnnotation             = "client-qps"
 	ClientBurstAnnotation           = "client-burst"
 	PrometheusEnabledAnnotation     = "prometheus-metrics-enabled"
+	NetworkPoliciesEnabledEnvVar    = "NETWORK_POLICIES_ENABLED"
 
 	AnnotationParseErrorFmt = "Failed to verify '%s' annotation value '%s' for component %s " +
 		"(falling back to default value %v)"
@@ -66,6 +67,7 @@ type GlobalValues struct {
 	ImagePullSecret string            `json:"imagePullSecret,omitempty"`
 	ImageOverrides  map[string]string `json:"imageOverrides,omitempty"`
 	ProxyConfig     *ProxyConfig      `json:"proxyConfig,omitempty"`
+	NetworkPolicies *NetworkPolicies  `json:"networkPolicies,omitempty"`
 }
 
 // ProxyConfig contains proxy configuration values for the addon chart.
@@ -75,6 +77,34 @@ type ProxyConfig struct {
 	HTTPProxy  string `json:"HTTP_PROXY,omitempty"`
 	HTTPSProxy string `json:"HTTPS_PROXY,omitempty"`
 	NoProxy    string `json:"NO_PROXY,omitempty"`
+}
+
+// NetworkPolicies contains network policies configuration values for the addon chart.
+type NetworkPolicies struct {
+	Enabled bool `json:"enabled,omitempty"`
+}
+
+// GetNetworkPoliciesEnabled reads the environment variable
+// that determines whether network policies should be created.
+// Default true.
+func GetNetworkPoliciesEnabled() bool {
+	defaultVal := true
+
+	value := os.Getenv(NetworkPoliciesEnabledEnvVar)
+	if value == "" {
+		return defaultVal
+	}
+
+	enabled, err := strconv.ParseBool(value)
+	if err != nil {
+		log.Error(err, fmt.Sprintf(
+			"Failed to parse '%s' (falling back to default value %v)",
+			NetworkPoliciesEnabledEnvVar, defaultVal))
+
+		return defaultVal
+	}
+
+	return enabled
 }
 
 // BaseValues contains base values for the addon chart.
@@ -299,8 +329,8 @@ func GetLogLevel(level string) (int8, error) {
 // to 2 less than the user log level.
 func (cv *CommonValues) SetLogLevel(value string) error {
 	logLevel, err := GetLogLevel(value)
-	cv.UserArgs.LogLevel = logLevel
-	cv.UserArgs.PkgLogLevel = logLevel - 2
+	cv.LogLevel = logLevel
+	cv.PkgLogLevel = logLevel - 2
 
 	return err
 }
@@ -310,11 +340,11 @@ func (cv *CommonValues) SetEvaluationConcurrency(value string) error {
 	evaluationConcurrency, err := strconv.ParseUint(value, 10, 8)
 	if err != nil {
 		return fmt.Errorf("failed to parse evaluation concurrency value '%s' (falling back to default value %d): %w",
-			value, cv.UserArgs.EvaluationConcurrency, err)
+			value, cv.EvaluationConcurrency, err)
 	}
 
 	// This is safe because we specified the uint8 in ParseUint
-	cv.UserArgs.EvaluationConcurrency = uint8(evaluationConcurrency)
+	cv.EvaluationConcurrency = uint8(evaluationConcurrency)
 
 	return nil
 }
@@ -324,11 +354,11 @@ func (cv *CommonValues) SetClientQPS(value string) error {
 	clientQPS, err := strconv.ParseUint(value, 10, 8)
 	if err != nil {
 		return fmt.Errorf("failed to parse client QPS value '%s' (falling back to default value %d): %w",
-			value, cv.UserArgs.ClientQPS, err)
+			value, cv.ClientQPS, err)
 	}
 
 	// This is safe because we specified the uint8 in ParseUint
-	cv.UserArgs.ClientQPS = uint8(clientQPS)
+	cv.ClientQPS = uint8(clientQPS)
 
 	return nil
 }
@@ -336,8 +366,8 @@ func (cv *CommonValues) SetClientQPS(value string) error {
 // SetClientBurstFromEvaluationConcurrency sets the client burst for the addon
 // based on the evaluation concurrency.
 func (cv *CommonValues) SetClientBurstFromEvaluationConcurrency() {
-	if cv.UserArgs.EvaluationConcurrency != 0 && cv.UserArgs.ClientBurst == 0 {
-		cv.UserArgs.ClientBurst = cv.UserArgs.EvaluationConcurrency*22 + 1
+	if cv.EvaluationConcurrency != 0 && cv.ClientBurst == 0 {
+		cv.ClientBurst = cv.EvaluationConcurrency*22 + 1
 	}
 }
 
@@ -346,11 +376,11 @@ func (cv *CommonValues) SetClientBurst(value string) error {
 	clientBurst, err := strconv.ParseUint(value, 10, 8)
 	if err != nil {
 		return fmt.Errorf("failed to parse client burst value '%s' (falling back to default value %d): %w",
-			value, cv.UserArgs.ClientBurst, err)
+			value, cv.ClientBurst, err)
 	}
 
 	// This is safe because we specified the uint8 in ParseUint
-	cv.UserArgs.ClientBurst = uint8(clientBurst)
+	cv.ClientBurst = uint8(clientBurst)
 
 	return nil
 }
@@ -418,7 +448,7 @@ func (cv *CommonValues) SetCommonValuesFromCustomizedVariables(
 	//nolint:nlreturn,unparam
 	variableToFuncMap := map[string]func(string) error{
 		"logLevel":              cv.SetLogLevel,
-		"logEncoder":            func(value string) error { cv.UserArgs.LogEncoder = value; return nil },
+		"logEncoder":            func(value string) error { cv.LogEncoder = value; return nil },
 		"evaluationConcurrency": cv.SetEvaluationConcurrency,
 		"clientQPS":             cv.SetClientQPS,
 		"clientBurst":           cv.SetClientBurst,

--- a/pkg/addon/configpolicy/agent_addon.go
+++ b/pkg/addon/configpolicy/agent_addon.go
@@ -75,6 +75,9 @@ func getSkeletonValues() configPolicyUserValues {
 					ImageOverrides: map[string]string{
 						"config_policy_controller": os.Getenv("CONFIG_POLICY_CONTROLLER_IMAGE"),
 					},
+					NetworkPolicies: &policyaddon.NetworkPolicies{
+						Enabled: policyaddon.GetNetworkPoliciesEnabled(),
+					},
 				},
 			},
 		},
@@ -108,7 +111,7 @@ func getValuesFromAnnotations(
 	) (addonfactory.Values, error) {
 		userValues := getSkeletonValues()
 
-		err := userValues.CommonValues.SetCommonValues(cluster, addon, clusterClient)
+		err := userValues.SetCommonValues(cluster, addon, clusterClient)
 		if err != nil {
 			return nil, err
 		}
@@ -128,7 +131,7 @@ func getValuesFromAnnotations(
 			userValues.OperatorPolicy.DefaultNamespace = "openshift-operators"
 		}
 
-		if err := userValues.CommonValues.SetCommonValuesFromAnnotations(addon); err != nil {
+		if err := userValues.SetCommonValuesFromAnnotations(addon); err != nil {
 			log.Error(err, "failed to set common values from annotations")
 		}
 
@@ -149,7 +152,7 @@ func getValuesFromAnnotations(
 func getValuesFromCustomizedVariableValues(config addonapiv1beta1.AddOnDeploymentConfig) (addonfactory.Values, error) {
 	userValues := getSkeletonValues()
 
-	userValuesMap, err := userValues.CommonValues.SetCommonValuesFromCustomizedVariables(config)
+	userValuesMap, err := userValues.SetCommonValuesFromCustomizedVariables(config)
 	if err != nil {
 		log.Error(err, "error setting common addon values from customized variables")
 	}

--- a/pkg/addon/configpolicy/manifests/managedclusterchart/templates/network_policy.yaml
+++ b/pkg/addon/configpolicy/manifests/managedclusterchart/templates/network_policy.yaml
@@ -1,0 +1,55 @@
+# Copyright Contributors to the Open Cluster Management project
+
+# NetworkPolicy for config-policy-controller
+
+{{- if and .Values.global.networkPolicies.enabled .Values.networkPolicies }}
+
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: config-policy-controller-network-policy
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: {{ include "controller.fullname" . }}
+    chart: {{ include "controller.chart" . }}
+spec:
+  podSelector:
+    matchLabels:
+      app: {{ include "controller.fullname" . }}
+  policyTypes:
+  - Ingress
+  - Egress
+  ingress:
+  # Metrics ingress on port 8443 (secure metrics on OpenShift)
+  {{- if and .Values.prometheus.enabled (eq .Values.hostingKubernetesDistribution "OpenShift") }}
+  - ports:
+    - protocol: TCP
+      port: 8443
+  {{- else if .Values.prometheus.enabled }}
+  # Metrics ingress on port 8383
+  - ports:
+    - protocol: TCP
+      port: 8383
+  {{- end }}
+  # Webhook ingress from Kubernetes API server on port 9443
+  - ports:
+    - protocol: TCP
+      port: 9443
+  egress:
+  # DNS egress for name resolution
+  - ports:
+    - protocol: UDP
+      port: 53
+    - protocol: TCP
+      port: 53
+    - protocol: UDP
+      port: 5353
+    - protocol: TCP
+      port: 5353
+  # Kubernetes API server egress for cluster management operations
+  - ports:
+    - protocol: TCP
+      port: 443
+    - protocol: TCP
+      port: 6443
+{{- end }}

--- a/pkg/addon/configpolicy/manifests/managedclusterchart/values.yaml
+++ b/pkg/addon/configpolicy/manifests/managedclusterchart/values.yaml
@@ -18,6 +18,8 @@ hubKubeConfigSecret: config-policy-controller-hub-kubeconfig
 
 standaloneHubTemplatingSecret: ""
 
+networkPolicies: true
+
 operatorPolicy:
   disabled: false
   defaultNamespace: ""

--- a/pkg/addon/policyframework/agent_addon.go
+++ b/pkg/addon/policyframework/agent_addon.go
@@ -68,6 +68,9 @@ func getSkeletonValues() policyFrameworkUserValues {
 					ImageOverrides: map[string]string{
 						"governance_policy_framework_addon": os.Getenv("GOVERNANCE_POLICY_FRAMEWORK_ADDON_IMAGE"),
 					},
+					NetworkPolicies: &policyaddon.NetworkPolicies{
+						Enabled: policyaddon.GetNetworkPoliciesEnabled(),
+					},
 				},
 			},
 		},
@@ -82,7 +85,7 @@ func getValuesFromAnnotations(clusterClient clusterlistersv1.ManagedClusterListe
 	) (addonfactory.Values, error) {
 		userValues := getSkeletonValues()
 
-		err := userValues.CommonValues.SetCommonValues(cluster, addon, clusterClient)
+		err := userValues.SetCommonValues(cluster, addon, clusterClient)
 		if err != nil {
 			return nil, err
 		}
@@ -118,7 +121,7 @@ func getValuesFromAnnotations(clusterClient clusterlistersv1.ManagedClusterListe
 			}
 		}
 
-		if err := userValues.CommonValues.SetCommonValuesFromAnnotations(addon); err != nil {
+		if err := userValues.SetCommonValuesFromAnnotations(addon); err != nil {
 			log.Error(err, "failed to set common values from annotations")
 		}
 
@@ -129,7 +132,7 @@ func getValuesFromAnnotations(clusterClient clusterlistersv1.ManagedClusterListe
 func getValuesFromCustomizedVariableValues(config addonapiv1beta1.AddOnDeploymentConfig) (addonfactory.Values, error) {
 	userValues := getSkeletonValues()
 
-	userValuesMap, err := userValues.CommonValues.SetCommonValuesFromCustomizedVariables(config)
+	userValuesMap, err := userValues.SetCommonValuesFromCustomizedVariables(config)
 	if err != nil {
 		log.Error(err, "error setting common addon values from customized variables")
 	}

--- a/pkg/addon/policyframework/manifests/managedclusterchart/templates/network_policy.yaml
+++ b/pkg/addon/policyframework/manifests/managedclusterchart/templates/network_policy.yaml
@@ -1,0 +1,53 @@
+# Copyright Contributors to the Open Cluster Management project
+
+# NetworkPolicy for governance-policy-framework-addon
+
+{{- if and .Values.global.networkPolicies.enabled .Values.networkPolicies }}
+
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: governance-policy-framework-addon
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: {{ include "controller.fullname" . }}
+    chart: {{ include "controller.chart" . }}
+spec:
+  podSelector:
+    matchLabels:
+      app: {{ include "controller.fullname" . }}
+  policyTypes:
+  - Ingress
+  - Egress
+  # Ingress rules
+  ingress:
+  # Metrics collection on port 8443 (secure metrics on OpenShift)
+  {{- if and .Values.prometheus.enabled (eq .Values.hostingKubernetesDistribution "OpenShift") }}
+  - ports:
+    - protocol: TCP
+      port: 8443
+  {{- else if .Values.prometheus.enabled }}
+  # Metrics collection on port 8383
+  - ports:
+    - protocol: TCP
+      port: 8383
+  {{- end }}
+  # Egress rules
+  egress:
+  # DNS queries for hostname resolution
+  - ports:
+    - protocol: UDP
+      port: 53
+    - protocol: TCP
+      port: 53
+    - protocol: UDP
+      port: 5353
+    - protocol: TCP
+      port: 5353
+  # Kubernetes API access
+  - ports:
+    - protocol: TCP
+      port: 443
+    - protocol: TCP
+      port: 6443
+{{- end }}

--- a/pkg/addon/policyframework/manifests/managedclusterchart/values.yaml
+++ b/pkg/addon/policyframework/manifests/managedclusterchart/values.yaml
@@ -20,6 +20,8 @@ syncPoliciesOnMulticlusterHub: false
 
 hubKubeConfigSecret: governance-policy-framework-hub-kubeconfig
 
+networkPolicies: true
+
 affinity: {}
 
 tolerations:


### PR DESCRIPTION
Enabled only when global annotation networkPolicies.enabled is true

ref: https://redhat.atlassian.net/browse/ACM-37743

Adds cert policy controller network policy + copy of https://github.com/open-cluster-management-io/governance-policy-addon-controller/pull/304

## Daily cluster test results

### Test 1: Test network policies enabled by default on addon-controller pods
```
# `OPERAND_IMAGE_GOVERNANCE_POLICY_ADDON_CONTROLLER` -> `quay.io/jalaw/governance-policy-addon-controller:latest ` 
# leave env var unset: NETWORK_POLICIES_ENABLED
```
<img width="1257" height="260" alt="Screenshot From 2026-08-10 13-53-47" src="https://github.com/user-attachments/assets/1bff9965-1f4b-4f0a-8a92-e7d468d5aacf" />

```
$ cd governance-policy-framework
$ export MANAGED_CLUSTER_NAME=local-cluster
$ cp ~/.kube/config kubeconfig_hub && cp kubeconfig_hub kubeconfig_managed
$ export TEST_ARGS='--label-filter=!etcd --json-report=report.json --junit-report=report.xml --output-dir=test-output'
make integration-test
```
<img width="1650" height="644" alt="Screenshot From 2026-08-10 13-26-15" src="https://github.com/user-attachments/assets/e266cfc5-aa2f-4989-ab4a-aa7c81217390" />

### Test 2: Test network policies toggled by new env var in https://github.com/stolostron/multiclusterhub-operator/pull/4551

- keep the same quay.io/jalaw/governance-policy-addon-controller:latest as test 1
- replace OPERAND_IMAGE_MULTICLUSTERHUB_OPERATOR with quay.io/jalaw/multiclusterhub-operator:latest
- Verify daily cluster default value of NETWORK_POLICIES_ENABLED=FALSE and network policies were removed
<img width="1670" height="466" alt="Screenshot From 2026-08-10 14-42-27" src="https://github.com/user-attachments/assets/a48af87b-b7eb-43da-b90c-053a248a3dbe" />

- Enable network policies and verify network policies created
```
jalaw:multiclusterhub-operator$ kubectl patch mch multiclusterhub -n open-cluster-management --type=merge \
  -p '{"spec":{"networkPolicies":{"enabled":true}}}'
multiclusterhub.operator.open-cluster-management.io/multiclusterhub patched
jalaw:multiclusterhub-operator$ kubectl get mch multiclusterhub -n open-cluster-management \
  -o jsonpath='{.spec.networkPolicies.enabled}{"\n"}'
true
```

<img width="1132" height="314" alt="Screenshot From 2026-08-10 15-34-55" src="https://github.com/user-attachments/assets/1dff1032-b38e-4b58-ba76-8ffafd94dd18" />

- Run the grc framework tests
```
jalaw:governance-policy-framework$ k get networkpolicy -n open-cluster-management | grep "grc"
grc-policy-addon-controller-network-policy   app=grc,component=ocm-policy-addon-ctrl,release=grc                9m59s
grc-policy-propagator-network-policy         app=grc,component=ocm-policy-propagator,release=grc                9m59s
jalaw:governance-policy-framework$ k get networkpolicy -n open-cluster-management-agent-addon
NAME                                                POD-SELECTOR                                                                                                 AGE
cert-policy-controller-network-policy               app=cert-policy-controller                                                                                   9m25s
cluster-proxy-proxy-agent-network-policy            open-cluster-management.io/addon=cluster-proxy,proxy.open-cluster-management.io/component-name=proxy-agent   3h
config-policy-controller-network-policy             app=config-policy-controller                                                                                 9m25s
governance-policy-framework-addon                   app=governance-policy-framework                                                                              9m25s
hypershift-addon-agent                              app=hypershift-addon-agent                                                                                   3h1m
managed-serviceaccount-addon-agent-network-policy   addon-agent=managed-serviceaccount                                                                           3h1m
work-manager-addon-agent-network-policy             component=work-manager                                                                                       3h1m
jalaw:governance-policy-framework$ export MANAGED_CLUSTER_NAME=local-cluster
jalaw:governance-policy-framework$ cp ~/.kube/config kubeconfig_hub && cp kubeconfig_hub kubeconfig_managed
jalaw:governance-policy-framework$ export TEST_ARGS='--label-filter=!etcd --json-report=report.json --junit-report=report.xml --output-dir=test-output'
jalaw:governance-policy-framework$ make integration-test
Checking installation of github.com/onsi/ginkgo/v2/ginkgo@v2.32.0
/home/jalaw/Github/stolostron/governance-policy-framework/bin/ginkgo -v --label-filter=!etcd --json-report=report.json --junit-report=report.xml --output-dir=test-output test/integration -- -cluster_namespace=local-cluster -k8s_client=oc -is_hosted=false -cluster_namespace_on_hub=local-cluster -patch_decisions=false -policy_collection_branch=main
Running Suite: GRC framework integration test suite - /home/jalaw/Github/stolostron/governance-policy-framework/test/integration
================================================================================================================================
```
<img width="1530" height="518" alt="Screenshot From 2026-08-11 15-24-09" src="https://github.com/user-attachments/assets/3fea8532-3a83-4f2e-87d6-7c12c6e8cfc2" />
